### PR TITLE
Travis integration (renamed)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,30 @@ language: minimal
 
 services:
   - docker
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install -y git
-
-# branches:
-#   only:
-#     - develop
-#     - master
 
 script:
   - docker build -t fragsoc/esports-bot .
 
-deploy:
-  provider: script
-  script: bash docker-push.sh
+stages:
+  - develop
+  - production
+  
+jobs:
+  include:
+  - stage : develop
+    env:
+     - DOCKER_TAG=develop
+    deploy:
+      provider: script
+      script: bash docker-push.sh
+      on:
+       branch: develop
+
+  - stage: master
+    env:
+     - DOCKER_TAG=master
+    deploy:
+      provider: script
+      script: bash docker-push.sh
+      on:
+       branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+---
+
+language: minimal
+
+services:
+  - docker
+  - git
+
+script:
+  - docker build -t fragsoc/esports-bot .
+
+deploy:
+  provider: script
+  script: bash docker-push.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,14 @@ language: minimal
 
 services:
   - docker
-  - git
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y git
+
+# branches:
+#   only:
+#     - develop
+#     - master
 
 script:
   - docker build -t fragsoc/esports-bot .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # UoY Esport Bot Rewrite
 
+<a href="https://travis-ci.com/FragSoc/esports-bot"><img src="https://img.shields.io/travis/com/fragsoc/esports-bot?style=flat-square" /></a>
+<a href="https://hub.docker.com/r/fragsoc/esports-bot"><img src="https://img.shields.io/docker/pulls/fragsoc/esports-bot?style=flat-square" /></a>
+<a href="https://github.com/FragSoc/esports-bot"><img src="https://img.shields.io/github/license/fragsoc/esports-bot?style=flat-square" /></a>
+
 ## How to set up an instance of this bot
 
 1. Clone this repository:

--- a/docker-push.sh
+++ b/docker-push.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 
+branch=$(git branch --show)
+docker_tag="fragsoc/esports-bot:${branch}"
+
+docker tag fragsoc/esports-bot ${docker_tag}
 docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
 docker push fragsoc/esports-bot

--- a/docker-push.sh
+++ b/docker-push.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-branch=$(git branch --show)
-docker_tag="fragsoc/esports-bot:${branch}"
-
-docker tag fragsoc/esports-bot ${docker_tag}
+docker tag fragsoc/esports-bot fragsoc/esports-bot:${DOCKER_TAG}
 docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
 docker push fragsoc/esports-bot

--- a/docker-push.sh
+++ b/docker-push.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+docker push fragsoc/esports-bot


### PR DESCRIPTION
These changes add automated builds facilitated by Travis CI.
On `develop` and `master`, fully built docker images will be pushed to [the docker central repo](https://hub.docker.com/r/fragsoc/esports-bot).
Also add some coloured shields to the readme, because why not?

Travis has also automatically hooked into the repo and informed of build results in the UI.

If we have testing suites setup in the future, these should be added as a build stage to get automatic test results in PRs and commits.