### PR TITLE
package-relative toml read & EsportsBot.STRINGS instance attribute

### DIFF
--- a/src/esportsbot/cogs/AdminCog.py
+++ b/src/esportsbot/cogs/AdminCog.py
@@ -7,7 +7,7 @@ from ..base_functions import send_to_log_channel
 class AdminCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.STRINGS = toml.load("../user_strings.toml")["admin"]
+        self.STRINGS = bot.STRINGS["admin"]
 
     @commands.command(aliases=['cls', 'purge', 'delete', 'Cls', 'Purge', 'Delete', 'Clear'])
     @commands.has_permissions(manage_messages=True)

--- a/src/esportsbot/cogs/DefaultRoleCog.py
+++ b/src/esportsbot/cogs/DefaultRoleCog.py
@@ -8,7 +8,7 @@ from ..base_functions import send_to_log_channel
 class DefaultRoleCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.STRINGS = toml.load("../user_strings.toml")["default_role"]
+        self.STRINGS = bot.STRINGS["default_role"]
 
     @commands.command()
     @commands.has_permissions(administrator=True)

--- a/src/esportsbot/cogs/LogChannelCog.py
+++ b/src/esportsbot/cogs/LogChannelCog.py
@@ -7,7 +7,7 @@ from ..base_functions import send_to_log_channel
 class LogChannelCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.STRINGS = toml.load("../user_strings.toml")["logging"]
+        self.STRINGS = bot.STRINGS["logging"]
 
     @commands.command()
     @commands.has_permissions(administrator=True)

--- a/src/esportsbot/generate_schema.py
+++ b/src/esportsbot/generate_schema.py
@@ -23,7 +23,7 @@ def generate_schema():
             role_ping_cooldown_seconds bigint NOT NULL,
             pingme_create_threshold int NOT NULL,
             pingme_create_poll_length_seconds bigint NOT NULL,
-            pingme_role_emoji text
+            pingme_role_emoji text,
             shared_role_id bigint
         );
         ALTER TABLE ONLY guild_info

--- a/src/esportsbot/lib/client.py
+++ b/src/esportsbot/lib/client.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 import os
 import signal
 import asyncio
+import toml
 
 from .exceptions import UnrecognisedReactionMenuMessage
 from .emotes import Emote
@@ -21,13 +22,14 @@ class EsportsBot(commands.Bot):
     :vartype reactionMenus: ReactionMenuDB
     """
 
-    def __init__(self, command_prefix: str, unknownCommandEmoji: Emote, **options):
+    def __init__(self, command_prefix: str, unknownCommandEmoji: Emote, userStringsFile: str, **options):
         """
         :param str command_prefix: The prefix to use for bot commands when evoking from discord.
         """
         super().__init__(command_prefix, **options)
         self.reactionMenus = ReactionMenuDB()
         self.unknownCommandEmoji = unknownCommandEmoji
+        self.STRINGS = toml.load(userStringsFile)
 
         signal.signal(signal.SIGINT, self.interruptReceived) # keyboard interrupt
         signal.signal(signal.SIGTERM, self.interruptReceived) # graceful exit request
@@ -228,5 +230,5 @@ def instance() -> EsportsBot:
     if _instance is None:
         intents = Intents.default()
         intents.members = True
-        _instance = EsportsBot('!', Emote.fromStr("⁉"), intents=intents)
+        _instance = EsportsBot('!', Emote.fromStr("⁉"), "esportsbot/user_strings.toml", intents=intents)
     return _instance


### PR DESCRIPTION
The path used to load `user_strings.toml` is now relative to the project root rather than the cog

Cogs should read now user strings from `EsportsBot.STRINGS` instead of loading the toml file again

https://github.com/FragSoc/esports-bot/issues/48
https://github.com/FragSoc/esports-bot/issues/49