### PR TITLE
non-blocking http requests for Twitch Integration

### DIFF
--- a/src/esportsbot/lib/client.py
+++ b/src/esportsbot/lib/client.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 import os
 import signal
 import asyncio
+import aiohttp
 
 from .exceptions import UnrecognisedReactionMenuMessage
 from .emotes import Emote
@@ -28,6 +29,7 @@ class EsportsBot(commands.Bot):
         super().__init__(command_prefix, **options)
         self.reactionMenus = ReactionMenuDB()
         self.unknownCommandEmoji = unknownCommandEmoji
+        self.httpClient = aiohttp.ClientSession()
 
         signal.signal(signal.SIGINT, self.interruptReceived) # keyboard interrupt
         signal.signal(signal.SIGTERM, self.interruptReceived) # graceful exit request
@@ -45,6 +47,7 @@ class EsportsBot(commands.Bot):
         """Shut down the bot gracefully.
         """
         print("[EsportsBot] Shutting down...")
+        await self.httpClient.close()
         await self.logout()
 
 


### PR DESCRIPTION
This is an untested port of the synchronous requests made by `TwitchIntegrationCog` over to `aiohttp`.

I'm not expecting this not to work, but it definitely needs to be tested by @Ryth-cs please, since you know how the cog should work.

You'll notice that there's actually very, very little that's different about the code which is quite nice.

Note that graceful shutdown of the http client on `SIGINT`/`SIGTERM` is set up, we just need to figure out why docker isn't passing the signal to the bot.