### PR TITLE
Fix/get_cleaned_id

### DIFF
--- a/src/esportsbot/base_functions.py
+++ b/src/esportsbot/base_functions.py
@@ -8,14 +8,43 @@ async def send_to_log_channel(self, guild_id, msg):
         await self.bot.get_channel(db_logging_call[0]['log_channel_id']).send(msg)
 
 
-def get_cleaned_id(pre_clean_data):
-    if str(pre_clean_data)[0] == '<':
-        if str(pre_clean_data)[2] == '&':
-            return int(str(pre_clean_data)[3:-1])
-        else:
-            return int(str(pre_clean_data)[2:-1])
-    else:
-        return int(pre_clean_data)
+def role_id_from_mention(pre_clean_data: str) -> int:
+    """Extracts the ID of a role from a role mention.
+    Will also accept strings containing a role ID, and will reject invalid integers with a ValueError.
+    This does validate the ID further, e.g the size of the ID, or the existence of a role with the ID.
+
+    :param str pre_clean_data: A string containing either a role mention or ID
+    :return: The ID quoted in pre_clean_data
+    :rtype: int
+    :raise ValueError: When given an ID containing non-integer characters
+    """
+    return int(pre_clean_data.lstrip("<&").rstrip(">"))
+
+
+def channel_id_from_mention(pre_clean_data: str) -> int:
+    """Extracts the ID of a channel from a channel mention.
+    Will also accept strings containing a channel ID, and will reject invalid integers with a ValueError.
+    This does validate the ID further, e.g the size of the ID, or the existence of a channel with the ID.
+
+    :param str pre_clean_data: A string containing either a channel mention or ID
+    :return: The ID quoted in pre_clean_data
+    :rtype: int
+    :raise ValueError: When given an ID containing non-integer characters
+    """
+    return int(pre_clean_data.lstrip("<#").rstrip(">"))
+
+
+def user_id_from_mention(pre_clean_data: str) -> int:
+    """Extracts the ID of a user from a user mention.
+    Will also accept strings containing a user ID, and will reject invalid integers with a ValueError.
+    This does validate the ID further, e.g the size of the ID, or the existence of a user with the ID.
+
+    :param str pre_clean_data: A string containing either a user mention or ID
+    :return: The ID quoted in pre_clean_data
+    :rtype: int
+    :raise ValueError: When given an ID containing non-integer characters
+    """
+    return int(pre_clean_data.lstrip("<@!").rstrip(">"))
 
 
 def get_whether_in_vm_master(guild_id, channel_id):

--- a/src/esportsbot/base_functions.py
+++ b/src/esportsbot/base_functions.py
@@ -38,6 +38,7 @@ def user_id_from_mention(pre_clean_data: str) -> int:
     """Extracts the ID of a user from a user mention.
     Will also accept strings containing a user ID, and will reject invalid integers with a ValueError.
     This does validate the ID further, e.g the size of the ID, or the existence of a user with the ID.
+    Accepting ! characters also accounts for member mentions where the member has a nickname.
 
     :param str pre_clean_data: A string containing either a user mention or ID
     :return: The ID quoted in pre_clean_data

--- a/src/esportsbot/cogs/DefaultRoleCog.py
+++ b/src/esportsbot/cogs/DefaultRoleCog.py
@@ -1,7 +1,7 @@
 import toml
 from discord.ext import commands
 from ..db_gateway import db_gateway
-from ..base_functions import get_cleaned_id
+from ..base_functions import role_id_from_mention
 from ..base_functions import send_to_log_channel
 
 
@@ -13,7 +13,7 @@ class DefaultRoleCog(commands.Cog):
     @commands.command()
     @commands.has_permissions(administrator=True)
     async def setdefaultrole(self, ctx, given_role_id=None):
-        cleaned_role_id = get_cleaned_id(
+        cleaned_role_id = role_id_from_mention(
             given_role_id) if given_role_id else False
         if cleaned_role_id:
             db_gateway().update('guild_info', set_params={

--- a/src/esportsbot/cogs/LogChannelCog.py
+++ b/src/esportsbot/cogs/LogChannelCog.py
@@ -1,7 +1,7 @@
 import toml
 from discord.ext import commands
 from ..db_gateway import db_gateway
-from ..base_functions import get_cleaned_id
+from ..base_functions import channel_id_from_mention
 from ..base_functions import send_to_log_channel
 
 class LogChannelCog(commands.Cog):
@@ -12,7 +12,7 @@ class LogChannelCog(commands.Cog):
     @commands.command()
     @commands.has_permissions(administrator=True)
     async def setlogchannel(self, ctx, given_channel_id=None):
-        cleaned_channel_id = get_cleaned_id(
+        cleaned_channel_id = channel_id_from_mention(
             given_channel_id) if given_channel_id else ctx.channel.id
         log_channel_exists = db_gateway().get(
             'guild_info', params={'guild_id': ctx.author.guild.id})

--- a/src/esportsbot/cogs/MusicCog.py
+++ b/src/esportsbot/cogs/MusicCog.py
@@ -109,10 +109,13 @@ class MusicCog(commands.Cog):
             message = Embed(title="A channel id is a required argument", colour=EmbedColours.red)
             await send_timed_message(ctx.channel, embed=message, timer=30)
             return False
-
-        cleaned_channel_id = channel_id_from_mention(given_channel_id)
-
-        is_valid_channel_id = len(str(cleaned_channel_id)) == 18
+        
+        try:
+            cleaned_channel_id = channel_id_from_mention(given_channel_id)
+        except ValueError:
+            is_valid_channel_id = False
+        else:
+            is_valid_channel_id = len(str(cleaned_channel_id)) == 18
 
         if not is_valid_channel_id:
             # The channel id given is not valid.. exit

--- a/src/esportsbot/cogs/MusicCog.py
+++ b/src/esportsbot/cogs/MusicCog.py
@@ -14,7 +14,7 @@ from discord import Message, VoiceClient, TextChannel, Embed, Colour, FFmpegOpus
 from discord.ext import commands, tasks
 from discord.ext.commands import Context
 
-from ..base_functions import get_cleaned_id
+from ..base_functions import channel_id_from_mention
 from ..db_gateway import db_gateway
 from ..lib.client import EsportsBot
 
@@ -110,9 +110,9 @@ class MusicCog(commands.Cog):
             await send_timed_message(ctx.channel, embed=message, timer=30)
             return False
 
-        cleaned_channel_id = get_cleaned_id(given_channel_id)
+        cleaned_channel_id = channel_id_from_mention(given_channel_id)
 
-        is_valid_channel_id = (len(str(cleaned_channel_id)) == 18) and strIsInt(cleaned_channel_id)
+        is_valid_channel_id = len(str(cleaned_channel_id)) == 18
 
         if not is_valid_channel_id:
             # The channel id given is not valid.. exit

--- a/src/esportsbot/cogs/TwitchIntegrationCog.py
+++ b/src/esportsbot/cogs/TwitchIntegrationCog.py
@@ -1,6 +1,6 @@
 from discord.ext import commands, tasks
 from ..db_gateway import db_gateway
-from ..base_functions import get_cleaned_id
+from ..base_functions import channel_id_from_mention
 import requests
 import aiohttp
 import asyncio
@@ -23,7 +23,7 @@ class TwitchIntegrationCog(commands.Cog):
             # Check if Twitch channel has already been added
             twitch_in_db = db_gateway().get('twitch_info', params={
                 'guild_id': ctx.author.guild.id, 'twitch_handle': twitch_handle.lower()})
-            cleaned_channel_id = get_cleaned_id(
+            cleaned_channel_id = channel_id_from_mention(
                 announce_channel)
             channel_mention = "<#" + str(cleaned_channel_id) + ">"
             if not twitch_in_db:
@@ -51,7 +51,7 @@ class TwitchIntegrationCog(commands.Cog):
             # Check if Twitch channel has already been added
             twitch_in_db = db_gateway().get('twitch_info', params={
                 'guild_id': ctx.author.guild.id, 'twitch_handle': twitch_handle.lower()})
-            cleaned_channel_id = get_cleaned_id(
+            cleaned_channel_id = channel_id_from_mention(
                 announce_channel)
             channel_mention = "<#" + str(cleaned_channel_id) + ">"
             if not twitch_in_db:
@@ -100,7 +100,7 @@ class TwitchIntegrationCog(commands.Cog):
             # Check if Twitch channel has already been added
             twitch_in_db = db_gateway().get('twitch_info', params={
                 'guild_id': ctx.author.guild.id, 'twitch_handle': twitch_handle.lower()})
-            cleaned_channel_id = get_cleaned_id(
+            cleaned_channel_id = channel_id_from_mention(
                 announce_channel)
             channel_mention = "<#" + str(cleaned_channel_id) + ">"
             if twitch_in_db:

--- a/src/esportsbot/cogs/TwitterIntegrationCog.py
+++ b/src/esportsbot/cogs/TwitterIntegrationCog.py
@@ -1,6 +1,6 @@
 from discord.ext import tasks, commands
 from ..db_gateway import db_gateway
-from ..base_functions import get_cleaned_id
+from ..base_functions import channel_id_from_mention
 import snscrape.modules.twitter as sntwitter
 import time
 
@@ -22,7 +22,7 @@ class TwitterIntegrationCog(commands.Cog):
                 twitter_in_db = db_gateway().get('twitter_info', params={
                     'guild_id': ctx.author.guild.id, 'twitter_handle': twitter_handle.lower()})
                 if not bool(twitter_in_db):
-                    cleaned_channel_id = get_cleaned_id(announce_channel)
+                    cleaned_channel_id = channel_id_from_mention(announce_channel)
                     channel_mention = "<#" + str(cleaned_channel_id) + ">"
                     previous_tweet_id = self.get_tweets(
                         twitter_handle)[0]['id']
@@ -63,7 +63,7 @@ class TwitterIntegrationCog(commands.Cog):
                     'guild_id': ctx.author.guild.id, 'twitter_handle': twitter_handle.lower()})
                 if bool(twitter_in_db):
                     # In DB
-                    cleaned_channel_id = get_cleaned_id(announce_channel)
+                    cleaned_channel_id = channel_id_from_mention(announce_channel)
                     channel_mention = "<#" + str(cleaned_channel_id) + ">"
                     db_gateway().update('twitter_info', set_params={'channel_id': cleaned_channel_id}, where_params={
                         'guild_id': ctx.author.guild.id, 'twitter_handle': twitter_handle.lower()})


### PR DESCRIPTION
Replaces `base_functions.get_cleaned_id`, a function which worked only for roles but was being used for channels as well, with `base_functions.role_id_from_mention`, `channel_id_from_mention` and `user_id_from_mention`.

Please ask if you have questions about the semantics

Fixes https://github.com/FragSoc/esports-bot/issues/23