### PR TITLE
Fixed bugs relating to MusicCog

### DIFF
--- a/src/esportsbot/bot.py
+++ b/src/esportsbot/bot.py
@@ -262,7 +262,7 @@ async def on_message(message):
             # Handle music channel messages
             guild_id = message.guild.id
             music_channel_in_db = client.MUSIC_CHANNELS.get(guild_id)
-            if music_channel_in_db:
+            if music_channel_in_db == message.channel.id:
                 # The message was in a music channel and a song should be found
                 music_cog_instance = client.cogs.get('MusicCog')
                 await music_cog_instance.on_message_handle(message)

--- a/src/esportsbot/cogs/AdminCog.py
+++ b/src/esportsbot/cogs/AdminCog.py
@@ -9,9 +9,9 @@ class AdminCog(commands.Cog):
         self.bot = bot
         self.STRINGS = bot.STRINGS["admin"]
 
-    @commands.command(aliases=['cls', 'purge', 'delete', 'Cls', 'Purge', 'Delete', 'Clear'])
+    @commands.command(aliases=['cls', 'purge', 'delete', 'Cls', 'Purge', 'Delete'])
     @commands.has_permissions(manage_messages=True)
-    async def clear(self, ctx, amount=5):
+    async def clear_messages(self, ctx, amount=5):
         await ctx.channel.purge(limit=int(amount) + 1)
         await send_to_log_channel(
             self,

--- a/src/esportsbot/cogs/MusicCog.py
+++ b/src/esportsbot/cogs/MusicCog.py
@@ -778,7 +778,7 @@ class MusicCog(commands.Cog):
 
         if not message.author.voice:
             # User is not in a voice channel.. exit
-            message_title = self.user_strings["no_voice_voice_channel"].format(author=message.author.mention)
+            message_title = self.user_strings["no_voice_voice_channel"].format(author=message.author.name)
             await send_timed_message(
                 channel=message.channel,
                 embed=Embed(title=message_title,
@@ -789,7 +789,7 @@ class MusicCog(commands.Cog):
 
         if not message.author.voice.channel.permissions_for(message.guild.me).connect:
             # The bot does not have permission to join the channel.. exit
-            message_title = self.user_strings["no_perms_voice_channel"].format(author=message.author.mention)
+            message_title = self.user_strings["no_perms_voice_channel"].format(author=message.author.name)
             await send_timed_message(
                 channel=message.channel,
                 embed=Embed(title=message_title,
@@ -809,7 +809,7 @@ class MusicCog(commands.Cog):
         else:
             if self._currently_active.get(message.guild.id).get('channel_id') != message.author.voice.channel.id:
                 # The bot is already being used in the current guild.
-                message_title = self.user_strings["wrong_voice_voice_channel"].format(author=message.author.mention)
+                message_title = self.user_strings["wrong_voice_voice_channel"].format(author=message.author.name)
                 await send_timed_message(
                     channel=message.channel,
                     embed=Embed(title=message_title,
@@ -1138,7 +1138,7 @@ class MusicCog(commands.Cog):
 
         if not ctx.author.voice:
             # User is not in a voice channel
-            message_title = self.user_strings["no_voice_voice_channel"].format(author=ctx.author.mention)
+            message_title = self.user_strings["no_voice_voice_channel"].format(author=ctx.author.name)
             await send_timed_message(
                 channel=ctx.channel,
                 embed=Embed(title=message_title,
@@ -1149,7 +1149,7 @@ class MusicCog(commands.Cog):
 
         if self._currently_active.get(ctx.guild.id).get('channel_id') != ctx.author.voice.channel.id:
             # The user is not in the same voice channel as the bot
-            message_title = self.user_strings["wrong_voice_voice_channel"].format(author=ctx.author.mention)
+            message_title = self.user_strings["wrong_voice_voice_channel"].format(author=ctx.author.name)
             await send_timed_message(
                 channel=ctx.channel,
                 embed=Embed(title=message_title,


### PR DESCRIPTION
- There was an issue where the AdminCog used the `clear` command which was conflicting with the MusicCog `clearqueue` command alias. AdminCog's method name has been changed to `clear_messages` and its alias removed.
- There was an issue where once the music channel was set all messages would be deleted no matter the channel due to not checking the channel id of the message's channel.
- There was an issue where the author of a message was being mentioned but was in an embed and hence was not appearing correctly. This has been changed to just say the author's name instead of mentioning.