### PR TITLE
Move from `send_to_log_channel` to `client.adminLog`

### DIFF
--- a/src/esportsbot/base_functions.py
+++ b/src/esportsbot/base_functions.py
@@ -2,12 +2,6 @@ from esportsbot.db_gateway import DBGatewayActions
 from esportsbot.models import Voicemaster_master, Voicemaster_slave, Guild_info
 
 
-async def send_to_log_channel(self, guild_id, msg):
-    db_logging_call = DBGatewayActions().get(Guild_info, guild_id=guild_id)
-    if db_logging_call.log_channel_id:
-        await self.bot.get_channel(db_logging_call.log_channel_id).send(msg)
-
-
 def role_id_from_mention(pre_clean_data: str) -> int:
     """Extracts the ID of a role from a role mention.
     Will also accept strings containing a role ID, and will reject invalid integers with a ValueError.

--- a/src/esportsbot/cogs/AdminCog.py
+++ b/src/esportsbot/cogs/AdminCog.py
@@ -1,6 +1,6 @@
-from discord.ext import commands
-from esportsbot.base_functions import send_to_log_channel
 import os
+
+from discord.ext import commands
 
 devs = os.getenv("DEV_IDS").replace(" ", "").split(",")
 
@@ -29,11 +29,13 @@ class AdminCog(commands.Cog):
     @commands.has_permissions(manage_messages=True)
     async def clear_messages(self, ctx, amount=5):
         await ctx.channel.purge(limit=int(amount) + 1)
-        await send_to_log_channel(
-            self,
-            ctx.author.guild.id,
-            self.STRINGS['channel_cleared'].format(author_mention=ctx.author.mention,
-                                                   message_amount=amount)
+        await self.bot.adminLog(
+            ctx.message,
+            {
+                "Cog": str(type(self)),
+                "Message": self.STRINGS['channel_cleared'].format(author_mention=ctx.author.mention,
+                                                                  message_amount=amount)
+            }
         )
 
     @commands.command(

--- a/src/esportsbot/cogs/DefaultRoleCog.py
+++ b/src/esportsbot/cogs/DefaultRoleCog.py
@@ -1,7 +1,7 @@
 from discord.ext import commands
+from esportsbot.base_functions import role_id_from_mention
 from esportsbot.db_gateway import DBGatewayActions
 from esportsbot.models import Guild_info
-from esportsbot.base_functions import role_id_from_mention, send_to_log_channel
 
 
 class DefaultRoleCog(commands.Cog):
@@ -18,13 +18,23 @@ class DefaultRoleCog(commands.Cog):
         if guild.default_role_id:
             default_role = member.guild.get_role(guild.default_role_id)
             await member.add_roles(default_role)
-            await send_to_log_channel(
-                self,
-                member.guild.id,
-                f"{member.mention} has joined the server and received the {default_role.mention} role"
+            await self.bot.adminLog(
+                None,
+                {
+                    "Cog": str(type(self)),
+                    "Message": f"{member.mention} has joined the server and received the {default_role.mention} role"
+                },
+                guildID=member.guild.id
             )
         else:
-            await send_to_log_channel(self, member.guild.id, f"{member.mention} has joined the server")
+            await self.bot.adminLog(
+                None,
+                {
+                    "Cog": str(type(self)),
+                    "Message": f"{member.mention} has joined the server"
+                },
+                guildID=member.guild.id
+            )
 
     @commands.command(
         name="setdefaultrole",
@@ -46,11 +56,15 @@ class DefaultRoleCog(commands.Cog):
 
             await ctx.channel.send(self.STRINGS['default_role_set'].format(role_id=cleaned_role_id))
             default_role = ctx.author.guild.get_role(cleaned_role_id)
-            await send_to_log_channel(
-                self,
-                ctx.author.guild.id,
-                self.STRINGS['default_role_set_log'].format(author=ctx.author.mention,
-                                                            role_mention=default_role.mention)
+            await self.bot.adminLog(
+                ctx.message,
+                {
+                    "Cog":
+                    str(type(self)),
+                    "Message":
+                    self.STRINGS['default_role_set_log'].format(author=ctx.author.mention,
+                                                                role_mention=default_role.mention)
+                }
             )
         else:
             await ctx.channel.send(self.STRINGS['default_role_set_missing_params'])
@@ -88,10 +102,12 @@ class DefaultRoleCog(commands.Cog):
             guild.default_role_id = None
             DBGatewayActions().update(guild)
             await ctx.channel.send(self.STRINGS['default_role_removed'])
-            await send_to_log_channel(
-                self,
-                ctx.author.guild.id,
-                self.STRINGS['default_role_removed_log'].format(author_mention=ctx.author.mention)
+            await self.bot.adminLog(
+                ctx.message,
+                {
+                    "Cog": str(type(self)),
+                    "Message": self.STRINGS['default_role_removed_log'].format(author_mention=ctx.author.mention)
+                }
             )
         else:
             await ctx.channel.send(self.STRINGS['default_role_missing'])

--- a/src/esportsbot/cogs/LogChannelCog.py
+++ b/src/esportsbot/cogs/LogChannelCog.py
@@ -1,7 +1,7 @@
 from discord.ext import commands
+from esportsbot.base_functions import channel_id_from_mention
 from esportsbot.db_gateway import DBGatewayActions
 from esportsbot.models import Guild_info
-from esportsbot.base_functions import channel_id_from_mention, send_to_log_channel
 
 
 class LogChannelCog(commands.Cog):
@@ -22,10 +22,12 @@ class LogChannelCog(commands.Cog):
             db_item = Guild_info(guild_id=ctx.guild.id, log_channel_id=cleaned_channel_id)
             DBGatewayActions().create(db_item)
             await ctx.channel.send(self.STRINGS["channel_set"].format(channel_id=cleaned_channel_id))
-            await send_to_log_channel(
-                self,
-                ctx.author.guild.id,
-                self.STRINGS["channel_set_notify_in_channel"].format(author_mention=ctx.author.mention),
+            await self.bot.adminLog(
+                ctx.message,
+                {
+                    "Cog": str(type(self)),
+                    "Message": self.STRINGS["channel_set_notify_in_channel"].format(author_mention=ctx.author.mention)
+                }
             )
             return
 
@@ -37,10 +39,12 @@ class LogChannelCog(commands.Cog):
         guild.log_channel_id = cleaned_channel_id
         DBGatewayActions().update(guild)
         await ctx.channel.send(self.STRINGS["channel_set"].format(channel_id=cleaned_channel_id))
-        await send_to_log_channel(
-            self,
-            ctx.author.guild.id,
-            self.STRINGS["channel_set_notify_in_channel"].format(author_mention=ctx.author.mention),
+        await self.bot.adminLog(
+            ctx.message,
+            {
+                "Cog": str(type(self)),
+                "Message": self.STRINGS["channel_set_notify_in_channel"].format(author_mention=ctx.author.mention)
+            }
         )
 
     @commands.command(name="getlogchannel", usage="", help="Gets the server logging channel for bot actions")

--- a/src/esportsbot/cogs/VoicemasterCog.py
+++ b/src/esportsbot/cogs/VoicemasterCog.py
@@ -20,7 +20,7 @@ class VoicemasterCog(commands.Cog):
             await this_instance.adminLog(
                 None,
                 {"Message": "I need the permission `move members` in this guild to be able to perform Voicemaster"},
-                member.guild.id
+                guildID=member.guild.id
             )
             return
 
@@ -38,7 +38,7 @@ class VoicemasterCog(commands.Cog):
                         "Cog": "VoiceMaster",
                         "Message": f"{member.mention} has deleted a VM slave"
                     },
-                    member.guild.id
+                    guildID=member.guild.id
                 )
             else:
                 # Still others in VC
@@ -63,7 +63,7 @@ class VoicemasterCog(commands.Cog):
                     "Cog": "VoiceMaster",
                     "Message": f"{member.mention} has created a VM slave"
                 },
-                member.guild.id
+                guildID=member.guild.id
             )
 
     @commands.command(

--- a/src/esportsbot/cogs/VoicemasterCog.py
+++ b/src/esportsbot/cogs/VoicemasterCog.py
@@ -1,7 +1,6 @@
 from discord.ext import commands
 from esportsbot.base_functions import (get_whether_in_vm_master, get_whether_in_vm_slave)
 from esportsbot.db_gateway import DBGatewayActions
-from esportsbot.lib.client import instance
 from esportsbot.models import Voicemaster_master, Voicemaster_slave
 
 
@@ -16,8 +15,7 @@ class VoicemasterCog(commands.Cog):
         after_channel_id = after.channel.id if after.channel else False
 
         if not member.guild.me.guild_permissions.move_members:
-            this_instance = instance()
-            await this_instance.adminLog(
+            await self.bot.adminLog(
                 None,
                 {"Message": "I need the permission `move members` in this guild to be able to perform Voicemaster"},
                 guildID=member.guild.id
@@ -31,8 +29,7 @@ class VoicemasterCog(commands.Cog):
                 # Nobody else in VC
                 await before.channel.delete()
                 DBGatewayActions().delete(vm_slave)
-                this_instance = instance()
-                await this_instance.adminLog(
+                await self.bot.adminLog(
                     None,
                     {
                         "Cog": "VoiceMaster",
@@ -56,8 +53,7 @@ class VoicemasterCog(commands.Cog):
                                   locked=False)
             )
             await member.move_to(new_slave_channel)
-            this_instance = instance()
-            await this_instance.adminLog(
+            await self.bot.adminLog(
                 None,
                 {
                     "Cog": "VoiceMaster",
@@ -85,8 +81,7 @@ class VoicemasterCog(commands.Cog):
                 DBGatewayActions().create(Voicemaster_master(guild_id=ctx.author.guild.id, channel_id=given_channel_id))
                 await ctx.channel.send("This VC has now been set as a VM master")
                 new_vm_master_channel = self.bot.get_channel(int(given_channel_id))
-                this_instance = instance()
-                await this_instance.adminLog(
+                await self.bot.adminLog(
                     ctx.message,
                     {
                         "Cog":
@@ -143,8 +138,7 @@ class VoicemasterCog(commands.Cog):
                 DBGatewayActions().delete(channel_exists)
                 await ctx.channel.send(self.STRINGS['success_vm_unset'])
                 removed_vm_master = self.bot.get_channel(given_channel_id)
-                this_instance = instance()
-                await this_instance.adminLog(
+                await self.bot.adminLog(
                     ctx.message,
                     {
                         "Cog":
@@ -170,8 +164,7 @@ class VoicemasterCog(commands.Cog):
         for vm_master in all_vm_masters:
             DBGatewayActions().delete(vm_master)
         await ctx.channel.send(self.STRINGS['success_vm_masters_cleared'])
-        this_instance = instance()
-        await this_instance.adminLog(
+        await self.bot.adminLog(
             ctx.message,
             {
                 "Cog": "VoiceMaster",
@@ -190,8 +183,7 @@ class VoicemasterCog(commands.Cog):
                 await vm_slave_channel.delete()
             DBGatewayActions().delete(vm_slave)
         await ctx.channel.send(self.STRINGS['success_vm_slaves_cleared'])
-        this_instance = instance()
-        await this_instance.adminLog(
+        await self.bot.adminLog(
             ctx.message,
             {
                 "Cog": "VoiceMaster",
@@ -218,8 +210,7 @@ class VoicemasterCog(commands.Cog):
                     DBGatewayActions().update(in_vm_slave)
                     await ctx.author.voice.channel.edit(user_limit=len(ctx.author.voice.channel.members))
                     await ctx.channel.send(self.STRINGS['success_slave_locked'])
-                    this_instance = instance()
-                    await this_instance.adminLog(
+                    await self.bot.adminLog(
                         ctx.message,
                         {
                             "Cog": "VoiceMaster",
@@ -256,8 +247,7 @@ class VoicemasterCog(commands.Cog):
                     in_vm_slave.locked = False
                     DBGatewayActions().update(in_vm_slave)
                     await ctx.author.voice.channel.edit(user_limit=0)
-                    this_instance = instance()
-                    await this_instance.adminLog(
+                    await self.bot.adminLog(
                         ctx.message,
                         {
                             "Cog": "VoiceMaster",

--- a/src/esportsbot/cogs/VoicemasterCog.py
+++ b/src/esportsbot/cogs/VoicemasterCog.py
@@ -32,7 +32,7 @@ class VoicemasterCog(commands.Cog):
                 await self.bot.adminLog(
                     None,
                     {
-                        "Cog": "VoiceMaster",
+                        "Cog": str(type(self)),
                         "Message": f"{member.mention} has deleted a VM slave"
                     },
                     guildID=member.guild.id
@@ -56,7 +56,7 @@ class VoicemasterCog(commands.Cog):
             await self.bot.adminLog(
                 None,
                 {
-                    "Cog": "VoiceMaster",
+                    "Cog": str(type(self)),
                     "Message": f"{member.mention} has created a VM slave"
                 },
                 guildID=member.guild.id
@@ -89,7 +89,6 @@ class VoicemasterCog(commands.Cog):
                         "Message":
                         f"{ctx.author.mention} has made {new_vm_master_channel.name} - {new_vm_master_channel.id} a VM master VC"
                     },
-                    None,
                 )
             elif is_a_master:
                 # This already exists as a master
@@ -150,7 +149,6 @@ class VoicemasterCog(commands.Cog):
                             channel_id=removed_vm_master.id
                         )
                     },
-                    None,
                 )
             else:
                 await ctx.channel.send(self.STRINGS['error_not_vm'])
@@ -167,10 +165,9 @@ class VoicemasterCog(commands.Cog):
         await self.bot.adminLog(
             ctx.message,
             {
-                "Cog": "VoiceMaster",
+                "Cog": str(type(self)),
                 "Message": self.STRINGS['log_vm_masters_cleared'].format(mention=ctx.author.mention)
             },
-            None
         )
 
     @commands.command(name="killallslaves", usage="", help="Deletes all Voicemaster slave channels from the server")
@@ -186,10 +183,9 @@ class VoicemasterCog(commands.Cog):
         await self.bot.adminLog(
             ctx.message,
             {
-                "Cog": "VoiceMaster",
+                "Cog": str(type(self)),
                 "Message": self.STRINGS['log_vm_slaves_cleared'].format(mention=ctx.author.mention)
             },
-            None
         )
 
     @commands.command(name="lockvm", aliases=["lock"], usage="", help="Locks the Voicemaster slave that you are currently in")
@@ -213,10 +209,9 @@ class VoicemasterCog(commands.Cog):
                     await self.bot.adminLog(
                         ctx.message,
                         {
-                            "Cog": "VoiceMaster",
+                            "Cog": str(type(self)),
                             "Message": self.STRINGS['log_slave_locked'].format(mention=ctx.author.mention)
                         },
-                        None
                     )
                 else:
                     await ctx.channel.send(self.STRINGS['error_already_locked'])
@@ -250,10 +245,9 @@ class VoicemasterCog(commands.Cog):
                     await self.bot.adminLog(
                         ctx.message,
                         {
-                            "Cog": "VoiceMaster",
+                            "Cog": str(type(self)),
                             "Message": self.STRINGS['log_slave_unlocked'].format(mention=ctx.author.mention)
                         },
-                        None
                     )
                 else:
                     await ctx.channel.send(self.STRINGS['error_already_unlocked'])


### PR DESCRIPTION
The constant pinging in the test server was getting to me, so here's a PR to use @Trimatix's embed-based `adminLog` function for them.