### PR TITLE
Remove section folding in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,13 @@ The list below describes the different "Cogs" of the bot, their associated comma
 
 ### Administrator Tools
  Adds a few commands useful for admin operations.
+
 #### !clear 
 * Aliases: `cls, purge, delete`
 * Clear the specified number of messages from the current text channel.
+
+#### !version
+* Get the current version of the bot.
 
 #### !members
 * List the current number of members in the server.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ The list below describes the different "Cogs" of the bot, their associated comma
 
 ### Administrator Tools
  Adds a few commands useful for admin operations.
-#### !clear_message * Aliases: `cls, purge, delete`
+#### !clear 
+* Aliases: `cls, purge, delete`
 * Clear the specified number of messages from the current text channel.
 
 #### !members

--- a/README.md
+++ b/README.md
@@ -120,11 +120,14 @@ The list below describes the different "Cogs" of the bot, their associated comma
 <summary>Log Channel</summary>
 
 ### Log Channel
- #### !setlogchannel <channel_mention | channel_id> * Set the log channel to the #'ed channel or given role ID.
+ #### !setlogchannel <channel_mention | channel_id> 
+* Set the log channel to the #'ed channel or given role ID.
 
-#### !getlogchannel * Gets the current log channel value.
+#### !getlogchannel 
+* Gets the current log channel value.
 
-#### !removelogchannel * Removes the current log channel value.
+#### !removelogchannel 
+* Removes the current log channel value.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -276,35 +276,43 @@ The `TWITCH_CALLBACK` is the URL to your HTTPS server. For testing you can use `
 
 - Run `ngrok http 443` and copy the `https` URL **not** the `htttp` URL and use that as your `TWITCH_CALLBACK` variable.
 
-#### !twitch createhook [optional: channel_mention] [optional: hook name]
+#### !twitch createhook \<channel mention> \<hook name>
 
-* Creates a Discord Webhook bound to the channel the command was executed in, unless a channel is given, and with a default name unless a name is given.
+* Creates a Discord Webhook bound to the channel given and with the name given, but prefixed with the Twitch Webhook prefix.
 
 #### !twitch deletehook \<hook name>
 
 * Deletes the given Discord Webhook.
 
-#### !twitch add \<twitch handle | twitch url> [optional: custom message]
+#### !twitch add \<channel name | channel url> \<hook name> [optional: custom message]
 
-* Adds a Twitch channel to be tracked in the current Discord server.
+* Adds a Twitch channel to be tracked in the given Webhook.
 * *__If a custom message is given, it must be surrounded by double quotes__*: `!twitch add <twitch_handle> "custom_message"`
 
-#### !twitch remove \<twitch handle>
+#### !twitch remove \<twitch handle> \<hook name>
 
 * Removes a Twitch channel from being tracked in the current Discord server.
 
-#### !twitch list
+#### !twitch list [optional: hook name]
 
 * Shows a list of all the currently tracked Twitch accounts and their custom messages.
+* If a hook name is given, only shows the information for the given hook.
 
-#### !twitch setmessage \<twitch handle> [optional: custom message]
+#### !twitch webhooks
+* Get a list of the current Discord Webhooks for Twitch notifications.
+
+#### !twitch setmessage \<twitch handle> \<hook name> [optional: custom message]
 
 * Sets the custom message of a Twitch channel. Can be left empty if the custom message is to be removed.
 * *__If a custom message is given, it must be surrounded by double quotes__*: `!twitch setmessage <twitch_handle> "custom_message"`
 
-#### !twitch getmessage \<twitch handle>
+#### !twitch getmessage \<twitch handle> [optional: hook name]
 
 * Gets the currently set custom message for a Twitch channel.
+* If a hook name is given, gets the currently set custom message for the Twitch channel in that Webhook.
+
+#### !twitch preview \<twitch handle> \<hook name>
+* Get a preview of the live notification for the given Twitch channel in the given Webhook.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,6 @@ python3 main.py
 ## Current Functions
 The list below describes the different "Cogs" of the bot, their associated commands, and any additional information required to set them up.
 
-<details>
-<summary>Voicemaster</summary>
-
 ### Voicemaster
  #### !setvmparent <channel_id>
 * Make the given ID a Voicemaster parent voice channel.
@@ -103,10 +100,6 @@ The list below describes the different "Cogs" of the bot, their associated comma
 
 #### !unlockvm 
 * Unlocks the Voicemaster child you're currently in.
-</details>
-
-<details>
-<summary>Default Role</summary>
 
 ### Default role
  #### !setdefaultroles <role_mention | role_id>
@@ -117,10 +110,6 @@ The list below describes the different "Cogs" of the bot, their associated comma
 
 #### !removedefaultroles
 * Removes the current default roles for the server.
-</details>
-
-<details>
-<summary>Log Channel</summary>
 
 ### Log Channel
  #### !setlogchannel <channel_mention | channel_id> 
@@ -131,10 +120,6 @@ The list below describes the different "Cogs" of the bot, their associated comma
 
 #### !removelogchannel 
 * Removes the current log channel value.
-</details>
-
-<details>
-<summary>Administrator Tools</summary>
 
 ### Administrator Tools
  Adds a few commands useful for admin operations.
@@ -160,11 +145,6 @@ The list below describes the different "Cogs" of the bot, their associated comma
 #### !reload-cog \<cog name>
 * Reloads the given cog.
 * *This command requires your user ID to be defined in the env file under `DEV_IDS`*
-
-</details>
-
-<details>
-<summary>Twitter Integration</summary>
 
 ### Twitter Integration
 
@@ -195,11 +175,6 @@ Requires the `ENABLE_TWITTER` variable to be set to `TRUE` in order to function.
 * Aliases: `accounts, get-all`.
 * Returns a list of the currently tracked Twitter accounts for the server.
 
-</details>
-
-<details>
-<summary>Event Channel Management</summary>
-
 ### Event Category Management
 
 Each server can have any number of named event categories, where each category creates a sign-in channel, a general chat, a voice chat and a role for the event. All commands in this cog required the `administrator` permission in Discord.
@@ -222,11 +197,6 @@ Each server can have any number of named event categories, where each category c
 #### !events delete-event \<event name>
 
 * Deletes all the channels in the category for the event and deletes the role created by the bot for the event.
-
-</details>
-
-<details>
-<summary>Twitch Integration</summary>
 
 ### Twitch Integration
 
@@ -314,11 +284,6 @@ The `TWITCH_CALLBACK` is the URL to your HTTPS server. For testing you can use `
 #### !twitch preview \<twitch handle> \<hook name>
 * Get a preview of the live notification for the given Twitch channel in the given Webhook.
 
-</details>
-
-<details>
-<summary>Role Reaction Menus</summary>
-
 ### Role Reaction Menus.
 
 Role reaction menus allow admins to create reactable menus that when reacted to grant defined roles to the user.
@@ -369,11 +334,6 @@ For devs:
 
 * Shows or Hides all role reaction menu footers, which contain the ID of the role reaction menu for ease of identification.
 * *Requires `administrator` permission in Discord*
-
-</details>
-
-<details>
-<summary>Poll Reaction Menus</summary>
 
 ### Poll Reaction menus.
 
@@ -432,11 +392,6 @@ For devs:
 * Aliases: `reset, clear, restart`
 * Removes all the current user-added reactions from the poll with the menu id given.
 * *You must be the owner of the poll or be an administrator*
-
-</details>
-
-<details>
-<summary>Music Bot</summary>
 
 ### Music Bot
 
@@ -540,11 +495,6 @@ For this cog to work, the `GOOGLE_API` env var must also be set, and instruction
 
 * Moves the song at position `from position` to position `to position` in the queue.
 
-</details>
-
-<details>
-<summary>Pingable Roles</summary>
-
 ### Pingable Roles
 
 Pingable roles are roles that can be voted in to be created by any user, and that once created have a cooldown tied to how often that role can be pinged.
@@ -636,5 +586,3 @@ After the poll finishes, a reaction menu gets created, allowing *any* user to re
 * Sets the emoji to use in the reaction menu for the given role.
 * The role provided __must__ be a pingable role created with this cog.
 * *Requires `administrator` permission in Discord*
-
-</details>

--- a/README.md
+++ b/README.md
@@ -86,18 +86,23 @@ The list below describes the different "Cogs" of the bot, their associated comma
  #### !setvmparent <channel_id>
 * Make the given ID a Voicemaster parent voice channel.
 
-#### !getvmparents * Get all the Voicemaster parent voice channels in the server.
+#### !getvmparents 
+* Get all the Voicemaster parent voice channels in the server.
 
 #### !removevmparent <channel_id>
 * Remove the given ID as a Voicemaster parent voice channel.
 
-#### !removeallparents * Remove all Voicemaster parents from the server.
+#### !removeallparents 
+* Remove all Voicemaster parents from the server.
 
-#### !deleteallchildren * Delete all the Voicemaster child channels in the server.
+#### !deleteallchildren 
+* Delete all the Voicemaster child channels in the server.
 
-#### !lockvm * Locks the Voicemaster child you're currently in to the number of current members.
+#### !lockvm 
+* Locks the Voicemaster child you're currently in to the number of current members.
 
-#### !unlockvm * Unlocks the Voicemaster child you're currently in.
+#### !unlockvm 
+* Unlocks the Voicemaster child you're currently in.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -109,11 +109,14 @@ The list below describes the different "Cogs" of the bot, their associated comma
 <summary>Default Role</summary>
 
 ### Default role
- #### !setdefaultroles <role_mention | role_id> * Sets the roles that the server gives to members when they join the server.
+ #### !setdefaultroles <role_mention | role_id>
+* Sets the roles that the server gives to members when they join the server.
 
-#### !getdefaultroles * Gets the current default roles set for the server.
+#### !getdefaultroles 
+* Gets the current default roles set for the server.
 
-#### !removedefaultroles * Removes the current default roles for the server.
+#### !removedefaultroles
+* Removes the current default roles for the server.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -439,27 +439,27 @@ For this cog to work, the `GOOGLE_API` env var must also be set, and instruction
 1. Click on `Create Credentials` and then `API key`.
 1. Copy the key given. For security, it is recommended that you "restrict key" and only enable `YouTube Data API v3`.
 
-#### musicchannel set \<channel mention> [optional: [args]]
+#### !musicadmin set \<channel mention> [optional: [args]]
 
 * This sets the channel mentioned to be used as the music channel. All messages into this channel will be considered music requests, and any music commands must be sent in this channel.
 * Optional args:
   * Using `-c` will clear the entire channel before setting it up as the music channel.
 * *Requires `administrator` permission in Discord*
 
-#### musicchannel get
+#### !musicadmin get
 * Sends the currently set music channel for the server.
 * *Requires `administrator` permission in Discord*
 
-#### musicchannel reset
+#### !musicadmin reset
 * This clears the current music channel and resets the preview and queue messages.
 * *Requires `administrator` permission in Discord*
 
-#### musicchannel remove
+#### !musicadmin remove
 
 * Unlinks the currently linked music channel from being the music channel. This will not delete the channel or its contents.
 * *Requires `administrator` permission in Discord*
 
-#### !music fix
+#### !musicadmin fix
 * If the bot has broken and thinks it is still in a Voice Channel, use this command to force it to reset.
 * *Requires `administrator` permission in Discord*
 

--- a/README.md
+++ b/README.md
@@ -601,13 +601,13 @@ After the poll finishes, a reaction menu gets created, allowing *any* user to re
 * The roles provided __must__ be pingable roles created with this cog.
 * *Requires `administrator` permission in Discord*
 
-#### !pingme role-cooldown \<role mention | role ID> <cooldown in seconds>
+#### !pingme role-cooldown \<role mention | role ID> \<cooldown in seconds>
 
 * Sets the ping cooldown for a specific role which overrides the server default for that role.
 * The role provided __must__ be a pingable role created with this cog.
 * *Requires `administrator` permission in Discord*
 
-#### !pingme role-emoji \<role mention | role ID> <emoji>
+#### !pingme role-emoji \<role mention | role ID> \<emoji>
 
 * Sets the emoji to use in the reaction menu for the given role.
 * The role provided __must__ be a pingable role created with this cog.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The list below describes the different "Cogs" of the bot, their associated comma
 #### !removeallparents 
 * Remove all Voicemaster parents from the server.
 
-#### !deleteallchildren 
+#### !removeallchildren 
 * Delete all the Voicemaster child channels in the server.
 
 #### !lockvm 

--- a/README.md
+++ b/README.md
@@ -83,21 +83,21 @@ The list below describes the different "Cogs" of the bot, their associated comma
 <summary>Voicemaster</summary>
 
 ### Voicemaster
- #### !setvmmaster <channel_id>
-* Make the given ID a Voicemaster master.
+ #### !setvmparent <channel_id>
+* Make the given ID a Voicemaster parent voice channel.
 
-#### !getvmmasters * Get all the Voicemaster masters in the server.
+#### !getvmparents * Get all the Voicemaster parent voice channels in the server.
 
-#### !removevmmaster <channel_id>
-* Remove the given ID as a Voicemaster master.
+#### !removevmparent <channel_id>
+* Remove the given ID as a Voicemaster parent voice channel.
 
-#### !removeallmasters * Remove all Voicemaster masters from the server.
+#### !removeallparents * Remove all Voicemaster parents from the server.
 
-#### !killallslaves * Kill all the Voicemaster slave channels in the server.
+#### !deleteallchildren * Delete all the Voicemaster child channels in the server.
 
-#### !lockvm * Locks the Voicemaster slave you're currently in to the number of current members.
+#### !lockvm * Locks the Voicemaster child you're currently in to the number of current members.
 
-#### !unlockvm * Unlocks the Voicemaster slave you're currently in.
+#### !unlockvm * Unlocks the Voicemaster child you're currently in.
 </details>
 
 <details>

--- a/src/esportsbot/cogs/AdminCog.py
+++ b/src/esportsbot/cogs/AdminCog.py
@@ -47,7 +47,7 @@ class AdminCog(commands.Cog):
         )
 
     @commands.check(is_dev)
-    @commands.command(name="version", help="Print the bot's version string")
+    @commands.command(name="version", help="Print the bot's version string", hidden=True)
     async def print_version(self, ctx):
         await ctx.channel.send(self.bot_version)
 
@@ -62,7 +62,7 @@ class AdminCog(commands.Cog):
         await ctx.channel.send(self.STRINGS['members'].format(member_count=ctx.guild.member_count))
 
     @commands.check(is_dev)
-    @commands.command(name="remove-cog")
+    @commands.command(name="remove-cog", hidden=True)
     async def remove_cog(self, context: commands.Context, cog_name: str):
         if "AdminCog" in cog_name:
             return
@@ -79,7 +79,7 @@ class AdminCog(commands.Cog):
             await context.send(f"The cog with name `{cog_name}` is not loaded.")
 
     @commands.check(is_dev)
-    @commands.command(name="add-cog")
+    @commands.command(name="add-cog", hidden=True)
     async def add_cog(self, context: commands.Context, cog_name: str):
         if "AdminCog" in cog_name:
             return
@@ -96,7 +96,7 @@ class AdminCog(commands.Cog):
             await context.send(f"The cog with name `{cog_name}` is already loaded.")
 
     @commands.check(is_dev)
-    @commands.command(name="reload-cog")
+    @commands.command(name="reload-cog", hidden=True)
     async def reload_cog(self, context: commands.Context, cog_name: str):
         try:
             package = "esportsbot.cogs."

--- a/src/esportsbot/cogs/AdminCog.py
+++ b/src/esportsbot/cogs/AdminCog.py
@@ -24,7 +24,7 @@ class AdminCog(commands.Cog):
         return str(ctx.author.id) in devs
 
     @commands.command(
-        name="clear_messages",
+        name="clear",
         aliases=['cls',
                  'purge',
                  'delete',

--- a/src/esportsbot/cogs/DefaultRoleCog.py
+++ b/src/esportsbot/cogs/DefaultRoleCog.py
@@ -46,11 +46,7 @@ class DefaultRoleCog(commands.Cog):
                 guildID=member.guild.id
             )
 
-    @commands.command(
-        name="setdefaultroles",
-        usage="<@role> <@role> <@role> ...",
-        help="Sets the roles that the server gives to members when they join the server"
-    )
+    @commands.command(name="setdefaultroles")
     @commands.has_permissions(administrator=True)
     async def setdefaultroles(self, ctx, *, args: str):
         role_list = args.split(" ")
@@ -86,11 +82,7 @@ class DefaultRoleCog(commands.Cog):
             else:
                 await ctx.channel.send(self.STRINGS['default_roles_set_error'])
 
-    @commands.command(
-        name="getdefaultroles",
-        usage="",
-        help="Gets the roles that the server gives to members when they join the server"
-    )
+    @commands.command(name="getdefaultroles")
     @commands.has_permissions(administrator=True)
     async def getdefaultroles(self, ctx):
         # Get all the default role for the server from database
@@ -106,11 +98,7 @@ class DefaultRoleCog(commands.Cog):
         else:
             await ctx.channel.send(self.STRINGS['default_role_missing'])
 
-    @commands.command(
-        name="removedefaultroles",
-        usage="",
-        help="Removes the roles that the server gives to members when they join the server"
-    )
+    @commands.command(name="removedefaultroles")
     @commands.has_permissions(administrator=True)
     async def removedefaultroles(self, ctx):
         # Get all the default role for the server from database

--- a/src/esportsbot/cogs/EventCategoriesCog.py
+++ b/src/esportsbot/cogs/EventCategoriesCog.py
@@ -224,11 +224,7 @@ class EventCategoriesCog(commands.Cog):
         voice_channel = list(filter(lambda x: VOICE_CHANNEL_SUFFIX in x.name, event_menu.event_category.voice_channels))[0]
         return general_channel, sign_in_channel, voice_channel
 
-    @commands.group(
-        name="events",
-        help="Create events with sign in menus dedicated event roles, and event channels.",
-        invoke_without_command=True
-    )
+    @commands.group(name="events", invoke_without_command=True)
     async def event_command_group(self, context: commands.context):
         """
         The command group used to make all commands sub-commands .
@@ -236,13 +232,7 @@ class EventCategoriesCog(commands.Cog):
         """
         pass
 
-    @event_command_group.command(
-        name="create-event",
-        usage="<event name> [shared role]",
-        help="Creates a new category, text channel, voice channel and sign-in menu with the given name, and "
-        "once opened will, the sign-in channel will be available to the given role. If no role is given, the server default "
-        "role will be used as the shared role. If there is no shared role @everyone is used."
-    )
+    @event_command_group.command(name="create-event")
     @commands.has_permissions(administrator=True)
     async def create_event(self, context: commands.Context, event_name: str, shared_role: Role = None):
         """
@@ -342,11 +332,7 @@ class EventCategoriesCog(commands.Cog):
             )
         )
 
-    @event_command_group.command(
-        name="open-event",
-        usage="<event name>",
-        help="Reveal the sign-in channel for the name event channel."
-    )
+    @event_command_group.command(name="open-event")
     @commands.has_permissions(administrator=True)
     async def open_event(self, context: commands.Context, event_name: str):
         """
@@ -391,11 +377,7 @@ class EventCategoriesCog(commands.Cog):
         )
         return
 
-    @event_command_group.command(
-        name="close-event",
-        usage="<event name>",
-        help="Close off the event channels to everyone that isn't an admin"
-    )
+    @event_command_group.command(name="close-event")
     @commands.has_permissions(administrator=True)
     async def close_event(self, context: commands.Context, event_name: str):
         """
@@ -435,11 +417,7 @@ class EventCategoriesCog(commands.Cog):
         await context.reply(self.user_strings["success_event_closed"])
         return
 
-    @event_command_group.command(
-        name="delete-event",
-        usage="<event name>",
-        help="Deletes the event channels and the temporary event role"
-    )
+    @event_command_group.command(name="delete-event")
     @commands.has_permissions(administrator=True)
     async def delete_event(self, context: commands.Context, event_name: str):
         """

--- a/src/esportsbot/cogs/MusicCog.py
+++ b/src/esportsbot/cogs/MusicCog.py
@@ -828,7 +828,7 @@ class MusicCog(commands.Cog):
         except AttributeError:
             return False
 
-    @commands.group(name="music", help="These are commands used to control the music bot.")
+    @commands.group(name="music")
     @commands.check(check_music_channel)
     @delete_after()
     async def command_group(self, context: commands.Context):
@@ -859,14 +859,7 @@ class MusicCog(commands.Cog):
         await context.send(self.unhandled_error_string)
         raise error
 
-    @command_group.command(
-        name="queue",
-        aliases=["songqueue",
-                 "songs",
-                 "songlist",
-                 "songslist"],
-        help="Gets the current list of songs in the queue"
-    )
+    @command_group.command(name="queue", aliases=["songqueue", "songs", "songlist", "songslist"])
     @delete_after()
     async def get_current_queue(self, context: commands.Context):
         """
@@ -884,13 +877,7 @@ class MusicCog(commands.Cog):
         queue_string = self.get_updated_queue_message(context.guild.id, complete_list=True)
         await send_timed_message(channel=context.channel, content=queue_string, timer=60)
 
-    @command_group.command(
-        name="join",
-        aliases=["connect"],
-        usage="[-f]",
-        help="Make the bot join the channel. If you are an admin you can force it join your voice channel "
-        "if it is currently in another channel with `-f` or `force`."
-    )
+    @command_group.command(name="join", aliases=["connect"])
     async def join_channel_command(self, context: commands.Context, force: str = ""):
         """
         Makes the bot join the channel of the author of the command. If the bot is in another channel and the author is an
@@ -912,13 +899,7 @@ class MusicCog(commands.Cog):
                 await send_timed_message(content=self.user_strings["unable_to_join"], channel=context.channel, timer=10)
                 return
 
-    @command_group.command(
-        name="kick",
-        aliases=["leave"],
-        usage="[-f]",
-        help="Kicks the bot from the channel. If you are an admin you can force it leave a voice channel "
-        "if it is currently in another channel with `-f` or `force`."
-    )
+    @command_group.command(name="kick", aliases=["leave"])
     async def leave_channel_command(self, context: commands.Context, force: str = ""):
         """
         Make the bot leave the voice channel of the author. If the author is not in the same voice channel as the bot and they
@@ -939,12 +920,7 @@ class MusicCog(commands.Cog):
                 await self.remove_active_guild(context.guild)
         await self.update_messages(context.guild.id)
 
-    @command_group.command(
-        name="skip",
-        usage="[skip to position]",
-        help="Skips the current song. If a number is given it will also skip to the song at the position given."
-        "For example, if 'songs to skip' is 4, the next song to play would be song 4 in the queue."
-    )
+    @command_group.command(name="skip")
     async def skip_song(self, context: commands.Context, skip_count=1):
         """
         The command used to skip the currently playing song. If the user also specifies a skip count,
@@ -980,11 +956,7 @@ class MusicCog(commands.Cog):
             self.active_guilds.get(guild_id)["queue"] = self.active_guilds.get(guild_id)["queue"][skip_count:]
             await self.play_queue(guild_id)
 
-    @command_group.command(
-        name="volume",
-        usage="<volume percentage>",
-        help="Sets the volume of the bot to the percentage given."
-    )
+    @command_group.command(name="volume")
     async def set_volume(self, context: commands.Context, volume_level):
         """
         Set the volume level of the current playback of the bot. This volume level will persist until the bot disconnects from
@@ -1022,7 +994,7 @@ class MusicCog(commands.Cog):
         self.active_guilds.get(guild_id)["volume"] = float(volume_level) / float(100)
         await self.update_messages(guild_id)
 
-    @command_group.command(name="shuffle", help="Shuffles the current queue.")
+    @command_group.command(name="shuffle")
     async def shuffle_queue(self, context: commands.Context):
         """
         Shuffles the current queue in a given guild.
@@ -1045,12 +1017,7 @@ class MusicCog(commands.Cog):
         shuffle(self.active_guilds.get(guild_id).get("queue"))
         await self.update_messages(guild_id)
 
-    @command_group.command(
-        name="clear",
-        aliases=["purge",
-                 "empty"],
-        help="Clears the current queue of all songs. Does not stop the currently playing song."
-    )
+    @command_group.command(name="clear", aliases=["purge", "empty"])
     async def clear_queue(self, context: commands.context):
         """
         Clear the current queue in a guild.
@@ -1072,13 +1039,7 @@ class MusicCog(commands.Cog):
             self.active_guilds.get(guild_id)["queue"] = []
         await self.update_messages(guild_id)
 
-    @command_group.command(
-        name="resume",
-        usage="[song to play]",
-        aliases=["play"],
-        help="Resumes playback of the current song. If a song is given and there is no current song, it is played,"
-        "otherwise it is added to the queue."
-    )
+    @command_group.command(name="resume", aliases=["play"])
     async def play_song(self, context: commands.Context, song_to_play=""):
         """
         Either resumes the current playback, adds a song to the queue or starts playback depending on the stats of the bot in
@@ -1119,7 +1080,7 @@ class MusicCog(commands.Cog):
         if member.guild.id not in self.playing_guilds:
             self.playing_guilds.append(member.guild.id)
 
-    @command_group.command(name="pause", help="Pauses the current song.")
+    @command_group.command(name="pause")
     async def pause_song(self, context: commands.Context):
         """
         Pauses the current playback of the bot in a given guild.
@@ -1143,12 +1104,7 @@ class MusicCog(commands.Cog):
         if self.active_guilds.get(guild_id)["voice_client"].is_playing():
             self.active_guilds.get(guild_id)["voice_client"].pause()
 
-    @command_group.command(
-        name="remove",
-        aliases=["removeat"],
-        usage="<song number>",
-        help="Removes a song from the given number in the queue."
-    )
+    @command_group.command(name="remove", aliases=["removeat"])
     async def remove_song(self, context: commands.Context, song_index: str = 1):
         """
         Removes a song from the queue using it's index. The index given as a param is 1-indexed, instead of 0-indexed.
@@ -1189,11 +1145,7 @@ class MusicCog(commands.Cog):
         except IndexError:
             return None
 
-    @command_group.command(
-        name="move",
-        usage="<from position> <to position>",
-        help="Moves a song from one position to another."
-    )
+    @command_group.command(name="move")
     async def move_song(self, context: commands.context, from_pos: str, to_pos: str):
         """
         Moves a song from one position in the queue to another position. The positions given as params are 1-indexed.
@@ -1260,11 +1212,16 @@ class MusicCog(commands.Cog):
         await self.update_messages(guild_id)
         return True
 
-    @command_group.command(
-        name="fix",
-        help="Kicks the bot from the current Voice Channel, clears the current queue and resets the music channel."
-    )
+    @commands.group(name="musicadmin")
     @commands.has_permissions(administrator=True)
+    async def music_channel_group(self, context: commands.Context):
+        """
+        The command group for the music channel management.
+        :param context: The context of the command.
+        """
+        pass
+
+    @music_channel_group.command(name="fix")
     async def guild_bot_reset_command(self, context: commands.Context):
         """
         Resets the music channel as well as attempts to disconnect the bot. This is to be used in-case there was an error
@@ -1275,21 +1232,7 @@ class MusicCog(commands.Cog):
         await self.disconnect_from_guild(context.guild)
         await self.reset_music_channel(context)
 
-    @commands.group(name="musicchannel", help="Manage music channel")
-    async def music_channel_group(self, context: commands.Context):
-        """
-        The command group for the music channel management.
-        :param context: The context of the command.
-        """
-        pass
-
-    @music_channel_group.command(
-        name="set",
-        usage="<channel mention> [optional args]",
-        help="Sets the music channel to the channel mentioned. To see possible optional args, "
-        "go to https://github.com/FragSoc/esports-bot#setmusicchannel-channel-mention-optional-args"
-    )
-    @commands.has_permissions(administrator=True)
+    @music_channel_group.command(name="set")
     async def set_music_channel_command(self, context: commands.Context, text_channel: TextChannel):
         """
         Sets the music channel for a given guild to the channel channel mentioned in the command. Extra args can be given to
@@ -1310,8 +1253,7 @@ class MusicCog(commands.Cog):
         await self.setup_music_channel(text_channel)
         await context.send(self.user_strings["music_channel_set"].format(channel=text_channel.mention))
 
-    @music_channel_group.command(name="get", help="Gets the current channel that is set as the music channel.")
-    @commands.has_permissions(administrator=True)
+    @music_channel_group.command(name="get")
     async def get_music_channel_command(self, context: commands.Context):
         """
         Gets the current channel that is set as the music channel.
@@ -1324,8 +1266,7 @@ class MusicCog(commands.Cog):
         else:
             await context.send(self.user_strings["music_channel_missing"])
 
-    @music_channel_group.command(name="reset", help="Clears the music channel and sends the preview and queue messages.")
-    @commands.has_permissions(administrator=True)
+    @music_channel_group.command(name="reset")
     async def reset_music_channel_command(self, context: commands.Context):
         """
         Resets the music channel to clear all the text and re-send the preview and queue messages.
@@ -1333,11 +1274,7 @@ class MusicCog(commands.Cog):
         """
         await self.reset_music_channel(context)
 
-    @music_channel_group.command(
-        name="remove",
-        help="Unlinks the currently set music channel from being the music channel. Does not delete the actual channel"
-    )
-    @commands.has_permissions(administrator=True)
+    @music_channel_group.command(name="remove")
     async def unlink_music_channel_command(self, context: commands.Context):
         if not self.music_channels.get(context.guild.id):
             await context.send(self.user_strings["music_channel_missing"])

--- a/src/esportsbot/cogs/MusicCog.py
+++ b/src/esportsbot/cogs/MusicCog.py
@@ -828,11 +828,7 @@ class MusicCog(commands.Cog):
         except AttributeError:
             return False
 
-    @commands.group(
-        name="music",
-        help="These are commands used to control the music bot. For more detailed command explanations, "
-        "go to https://github.com/FragSoc/esports-bot#music-bot",
-    )
+    @commands.group(name="music", help="These are commands used to control the music bot.")
     @commands.check(check_music_channel)
     @delete_after()
     async def command_group(self, context: commands.Context):
@@ -893,7 +889,7 @@ class MusicCog(commands.Cog):
         aliases=["connect"],
         usage="[-f]",
         help="Make the bot join the channel. If you are an admin you can force it join your voice channel "
-        "if it is currently in another channel with '-f' or 'force'."
+        "if it is currently in another channel with `-f` or `force`."
     )
     async def join_channel_command(self, context: commands.Context, force: str = ""):
         """
@@ -921,7 +917,7 @@ class MusicCog(commands.Cog):
         aliases=["leave"],
         usage="[-f]",
         help="Kicks the bot from the channel. If you are an admin you can force it leave a voice channel "
-        "if it is currently in another channel with '-f' or 'force'."
+        "if it is currently in another channel with `-f` or `force`."
     )
     async def leave_channel_command(self, context: commands.Context, force: str = ""):
         """

--- a/src/esportsbot/cogs/PingableRolesCog.py
+++ b/src/esportsbot/cogs/PingableRolesCog.py
@@ -575,7 +575,7 @@ class PingableRolesCog(commands.Cog):
             return None
         return db_item
 
-    @commands.group(name="pingme", help="Get and create custom roles with ping cooldown timers.", invoke_without_command=True)
+    @commands.group(name="pingme", invoke_without_command=True)
     async def ping_me(self, context: commands.Context):
         """
         The command group used to make all commands sub-commands .
@@ -583,7 +583,7 @@ class PingableRolesCog(commands.Cog):
         """
         pass
 
-    @ping_me.group(name="settings", help="Set default values for this server.")
+    @ping_me.group(name="settings")
     @commands.has_permissions(administrator=True)
     async def ping_me_settings(self, context: commands.Context):
         """
@@ -592,7 +592,7 @@ class PingableRolesCog(commands.Cog):
         """
         pass
 
-    @ping_me_settings.command(name="get-settings", help="Returns an embed of the current default settings for the server.")
+    @ping_me_settings.command(name="get-settings")
     async def get_guild_settings(self, context: commands.Context):
         """
         Returns a list of the current settings in a guild .
@@ -633,10 +633,7 @@ class PingableRolesCog(commands.Cog):
         embed.add_field(name=f"• Role Cooldown Seconds: {guild_settings.get('role_cooldown')}", value="​", inline=False)
         await context.send(embed=embed)
 
-    @ping_me_settings.command(
-        name="default-settings",
-        help="Resets all settings for this guild to the bot-defined defaults defined in the .env file."
-    )
+    @ping_me_settings.command(name="default-settings")
     async def default_settings(self, context: commands.Context):
         """
         Sets the settings for a guild back to the default settings .
@@ -674,12 +671,7 @@ class PingableRolesCog(commands.Cog):
         self.logger.info(f"{context.guild.name} has had its pingable settings set back to defaults!")
         await context.reply(self.user_strings["default_settings_set"])
 
-    @ping_me_settings.command(
-        name="poll-length",
-        usage="<poll length in seconds>",
-        help="Sets the default poll length to the given time in seconds. "
-        "Poll lengths can still be overridden by giving the poll length in the `create-role` command!"
-    )
+    @ping_me_settings.command(name="poll-length")
     async def set_poll_length(self, context: commands.Context, poll_length: int):
         """
         Sets the default poll length setting for a guild to the given value .
@@ -697,11 +689,7 @@ class PingableRolesCog(commands.Cog):
         await context.reply(self.user_strings["set_poll_length"].format(poll_length=poll_length))
         self.logger.info(f"Set {context.guild.name} default poll length to {poll_length}s")
 
-    @ping_me_settings.command(
-        name="poll-threshold",
-        usage="<number of votes threshold>",
-        help="Sets the number of votes required in a poll for the role to be created."
-    )
+    @ping_me_settings.command(name="poll-threshold")
     async def set_poll_threshold(self, context: commands.Context, vote_threshold: int):
         """
         Sets the poll vote threshold setting for a guild to the given value .
@@ -719,11 +707,7 @@ class PingableRolesCog(commands.Cog):
         await context.reply(self.user_strings["set_poll_threshold"].format(vote_threshold=vote_threshold))
         self.logger.info(f"Set {context.guild.name} poll threshold to {vote_threshold} votes")
 
-    @ping_me_settings.command(
-        name="ping-cooldown",
-        usage="<cooldown in seconds>",
-        help="Sets the default ping cooldown for any pingable role created with this cog."
-    )
+    @ping_me_settings.command(name="ping-cooldown")
     async def set_role_cooldown(self, context: commands.Context, role_cooldown: int):
         """
         Sets the default role ping cooldown setting for a guild to the given value .
@@ -747,11 +731,7 @@ class PingableRolesCog(commands.Cog):
         await context.reply(self.user_strings["set_role_cooldown"].format(cooldown=role_cooldown))
         self.logger.info(f"Set {context.guild.name} pingable role cooldown to {role_cooldown}s")
 
-    @ping_me_settings.command(
-        name="poll-emoji",
-        usage="<emoji>",
-        help="Sets the emoji to be used when creating a poll to vote in."
-    )
+    @ping_me_settings.command(name="poll-emoji")
     async def set_poll_emoji(self, context: commands.Context, poll_emoji: MultiEmoji):
         """
         Sets the poll voting emoji for a guild to the given emoji .
@@ -774,11 +754,7 @@ class PingableRolesCog(commands.Cog):
         await context.reply(self.user_strings["set_poll_emoji"].format(emoji=poll_emoji.discord_emoji))
         self.logger.info(f"Set {context.guild.name} poll emoji to {poll_emoji.name}")
 
-    @ping_me_settings.command(
-        name="role-emoji",
-        usage="<emoji>",
-        help="Sets the default emoji to be used in the role reaction menu for the pingable role once it has been created."
-    )
+    @ping_me_settings.command(name="role-emoji")
     async def set_role_emoji(self, context: commands.Context, role_emoji: MultiEmoji):
         """
         Sets the default role reaction emoji for a guild to the given emoji .
@@ -796,12 +772,7 @@ class PingableRolesCog(commands.Cog):
         await context.reply(self.user_strings["set_role_emoji"].format(emoji=role_emoji.discord_emoji))
         self.logger.info(f"Set {context.guild.name} role emoji to {role_emoji.name}")
 
-    @ping_me.command(
-        name="create-role",
-        usage="<role name> [Optional: poll length in seconds]",
-        help="Creates a new poll to create a role if the number of votes has surpassed the server's threshold after the"
-        " poll length has passed."
-    )
+    @ping_me.command(name="create-role")
     async def create_role(self, context: commands.Context, role_name: str, poll_length: int = None):
         """
         Creates a new role poll for a role with the name given . If no poll length is given, the guild default
@@ -840,11 +811,7 @@ class PingableRolesCog(commands.Cog):
         await context.reply(self.user_strings["create_success"])
         self.logger.info(f"Created a new poll for a pingable role with the name {role_name} in guild {context.guild.name}")
 
-    @ping_me.command(
-        name="delete-role",
-        usage="<one or many role mentions>",
-        help="Deletes the mentioned roles from the server. Cannot be used to delete non-pingable roles."
-    )
+    @ping_me.command(name="delete-role")
     @commands.has_permissions(administrator=True)
     async def delete_role(self, context: commands.Context):
         """
@@ -873,11 +840,7 @@ class PingableRolesCog(commands.Cog):
         await context.reply(self.user_strings["role_delete_success"].format(deleted_roles=deleted_string))
         self.logger.info(f"Deleted pingable roles: {deleted_string} in guild {context.guild.name}")
 
-    @ping_me.command(
-        name="convert-role",
-        usage="<One or many role mentions>",
-        help="Converts the mentioned roles into pingable roles and creates their reaction menus."
-    )
+    @ping_me.command(name="convert-role")
     @commands.has_permissions(administrator=True)
     async def convert_role(self, context: commands.Context):
         """
@@ -906,11 +869,7 @@ class PingableRolesCog(commands.Cog):
         await context.reply(self.user_strings["role_convert_success"].format(converted_roles=converted_string))
         self.logger.info(f"Converted pingable roles: {converted_string} in guild {context.guild.name}")
 
-    @ping_me.command(
-        name="convert-pingable",
-        usage="<one or many role mentions>",
-        help="Converts the mentioned roles from pingable roles into normal roles and deletes their reaction menus."
-    )
+    @ping_me.command(name="convert-pingable")
     @commands.has_permissions(administrator=True)
     async def convert_pingable(self, context: commands.Context):
         """
@@ -940,11 +899,7 @@ class PingableRolesCog(commands.Cog):
         await context.reply(self.user_strings["pingable_convert_success"].format(converted_roles=converted_string))
         self.logger.info(f"Converted pingable roles: {converted_string} in guild {context.guild.name}")
 
-    @ping_me.command(
-        name="role-cooldown",
-        usage="<role mention | role ID> <cooldown in seconds>",
-        help="Sets the ping cooldown for a specific role which overrides the server default for that role."
-    )
+    @ping_me.command(name="role-cooldown")
     @commands.has_permissions(administrator=True)
     async def change_pingable_role_cooldown(self, context: commands.Context, pingable_role: Role, cooldown_seconds: int):
         """
@@ -976,11 +931,7 @@ class PingableRolesCog(commands.Cog):
                                                               seconds=cooldown_seconds)
         )
 
-    @ping_me.command(
-        name="role-emoji",
-        usage="<role mention | role ID> <emoji>",
-        help="Sets the emoji to use in the reaction menu for the given role."
-    )
+    @ping_me.command(name="role-emoji")
     @commands.has_permissions(administrator=True)
     async def change_pingable_role_emoji(self, context: commands.Context, pingable_role: Role, role_emoji: MultiEmoji):
         """
@@ -1003,11 +954,7 @@ class PingableRolesCog(commands.Cog):
                                                            emoji=role_emoji.discord_emoji)
         )
 
-    @ping_me.command(
-        name="disable-role",
-        usage="<one or many role mentions>",
-        help="Disables the roles mentioned from being mentioned by non-administrators and disables their reaction menus."
-    )
+    @ping_me.command(name="disable-role")
     @commands.has_permissions(administrator=True)
     async def disable_pingable_role(self, context: commands.Context):
         """
@@ -1032,12 +979,7 @@ class PingableRolesCog(commands.Cog):
         disabled_string = str(disabled_roles).replace("[", "").replace("]", "")
         await context.reply(self.user_strings["roles_disabled"].format(disabled_roles=disabled_string))
 
-    @ping_me.command(
-        name="enable-role",
-        usage="<one or many role mentions>",
-        help="Enabled the roles mentioned to be mentioned by non-administrators and "
-        "allows their reaction menus to be reacted to."
-    )
+    @ping_me.command(name="enable-role")
     @commands.has_permissions(administrator=True)
     async def enabled_pingable_roles(self, context: commands.Context):
         """

--- a/src/esportsbot/cogs/RoleReactCog.py
+++ b/src/esportsbot/cogs/RoleReactCog.py
@@ -10,7 +10,6 @@ from esportsbot.DiscordReactableMenus.reactable_lib import get_menu
 from esportsbot.models import Role_menus
 
 DELETE_ON_CREATE = os.getenv("DELETE_ROLE_CREATION", "FALSE").lower() == "true"
-MAKE_MENU_GIT_README = "#roles-make-menu-title-description-mentioned-role-emoji"
 
 
 class RoleReactCog(commands.Cog):
@@ -97,12 +96,7 @@ class RoleReactCog(commands.Cog):
         """
         pass
 
-    @command_group.command(
-        name="make-menu",
-        usage="<title> <description> [<mentioned role> <emoji>]",
-        help="Creates a new role reaction menu with the given roles and their emojis. "
-        f"Go to https://github.com/FragSoc/esports-bot{MAKE_MENU_GIT_README} for more help regarding usage."
-    )
+    @command_group.command(name="make-menu")
     @commands.has_permissions(administrator=True)
     async def create_role_menu(self, context: commands.Context):
         """
@@ -137,12 +131,7 @@ class RoleReactCog(commands.Cog):
         if DELETE_ON_CREATE:
             await context.message.delete()
 
-    @command_group.command(
-        name="add-option",
-        usage="[optional: menu id] [<mentioned role> <emoji>]",
-        help="Adds a new option to a reaction menu, can be one or many. "
-        "If no ID is given it will add the option to the latest menu."
-    )
+    @command_group.command(name="add-option")
     @commands.has_permissions(administrator=True)
     async def add_menu_option(self, context: commands.Context, menu_id: str = None):
         """
@@ -176,12 +165,7 @@ class RoleReactCog(commands.Cog):
         await found_menu.update_message()
         self.add_or_update_db(found_menu.id)
 
-    @command_group.command(
-        name="remove-option",
-        usage="<emoji> [optional: menu id]",
-        help="Removes the role associated with the emoji from the given menu. "
-        "If no ID is given it will remove the option from the latest menu."
-    )
+    @command_group.command(name="remove-option")
     @commands.has_permissions(administrator=True)
     async def remove_menu_option(self, context: commands.Context, option_key: MultiEmoji, menu_id=None):
         """
@@ -200,11 +184,7 @@ class RoleReactCog(commands.Cog):
         await menu.update_message()
         self.add_or_update_db(menu.id)
 
-    @command_group.command(
-        name="disable-menu",
-        usage="[optional: menu id]",
-        help="Stops users from using the reaction menu to get roles. If no ID is given the latest menu will be disabled."
-    )
+    @command_group.command(name="disable-menu")
     @commands.has_permissions(administrator=True)
     async def disable_menu(self, context: commands.Context, menu_id=None):
         """
@@ -221,11 +201,7 @@ class RoleReactCog(commands.Cog):
         self.add_or_update_db(menu.id)
         await context.reply(self.user_strings["disable_menu"].format(menu_id=menu.id))
 
-    @command_group.command(
-        name="enable-menu",
-        usage="[optional: menu id]",
-        help="Allows users to use a reaction menu to get its roles. If no ID is given the latest menu will be enabled."
-    )
+    @command_group.command(name="enable-menu")
     @commands.has_permissions(administrator=True)
     async def enable_menu(self, context: commands.Context, menu_id=None):
         """
@@ -242,7 +218,7 @@ class RoleReactCog(commands.Cog):
         self.add_or_update_db(menu.id)
         await context.reply(self.user_strings["enable_menu"].format(menu_id=menu.id))
 
-    @command_group.command(name="delete-menu", usage="<menu id>", help="Deletes a given role reaction menu.")
+    @command_group.command(name="delete-menu")
     @commands.has_permissions(administrator=True)
     async def delete_menu(self, context: commands.Context, menu_id):
         """
@@ -262,7 +238,7 @@ class RoleReactCog(commands.Cog):
         self.db.delete(db_item)
         await context.reply(self.user_strings["delete_menu"].format(menu_id=menu.id))
 
-    @command_group.command(name="toggle-ids", help="Toggles the footer displaying the menu ID for all role reaction menus.")
+    @command_group.command(name="toggle-ids")
     @commands.has_permissions(administrator=True)
     async def toggle_show_ids(self, context: commands.Context):
         """

--- a/src/esportsbot/cogs/TwitchCog.py
+++ b/src/esportsbot/cogs/TwitchCog.py
@@ -608,11 +608,7 @@ class TwitchCog(commands.Cog):
             embed.add_field(name=item.twitch_handle, value=custom_message, inline=False)
         return embed
 
-    @commands.group(
-        pass_context=True,
-        invoke_without_command=True,
-        help="Access the Twitch integration functions with this command"
-    )
+    @commands.group(name="twitch",  invoke_without_command=True)
     async def twitch(self, ctx):
         """
         Empty command, purely used to organise subcommands to be under twitch <command> instead of having to ensure name
@@ -621,16 +617,7 @@ class TwitchCog(commands.Cog):
 
         pass
 
-    @twitch.command(
-        name="createhook",
-        aliases=["newhook",
-                 "makehook",
-                 "addhook"],
-        usage="<#channel> <hook name>",
-        help="Creates a new Discord Webhook bound to the mentioned channel. "
-        "The name will be prefixed with the Twitch Cog Webhook prefix to distinguish Twitch hooks from other Webhooks."
-        "The Webhooks created with the Twitch Cog do not need the prefix used in the name in order to reference them."
-    )
+    @twitch.command(name="createhook", aliases=["newhook",  "makehook", "addhook"])
     @commands.has_permissions(administrator=True)
     async def create_new_hook(self, context, bound_channel: discord.TextChannel, hook_name: str):
         """
@@ -656,11 +643,7 @@ class TwitchCog(commands.Cog):
                                                         hook_id=hook.id)
         )
 
-    @twitch.command(
-        name="deletehook",
-        usage="<hook name>",
-        help="Deletes the given Discord Webhook. This will also stop tracking accounts that were tied to the given Webhook."
-    )
+    @twitch.command(name="deletehook")
     @commands.has_permissions(administrator=True)
     async def delete_twitch_hook(self, context, hook_name: str):
         """
@@ -690,16 +673,7 @@ class TwitchCog(commands.Cog):
 
         await context.send(self.user_strings["webhook_deleted"].format(name=hook_info.get("name"), hook_id=hook_id))
 
-    @twitch.command(
-        name="add",
-        usage="<channel name|channel url> <webhook name> [custom message]",
-        help="Adds a Twitch channel to be tracked in the given Webhook. "
-        "This means when the channel goes live, its notification will be posted to the given Webhook. "
-        "A channel can be tied to more than one Webhook. "
-        "The custom message can be left empty, but when not, it will be used in the live notification. "
-        "A preview of what a notification looks like can be seen with the "
-        "`!twitch preview <twitch handle> <webhook name>` command."
-    )
+    @twitch.command(name="add")
     @commands.has_permissions(administrator=True)
     async def add_twitch_channel(self, context, channel, webhook_name, custom_message=None):
         """
@@ -753,11 +727,7 @@ class TwitchCog(commands.Cog):
             # Otherwise don't if it failed.
             await context.send(self.user_strings["generic_error"].format(channel=channel))
 
-    @twitch.command(
-        name="remove",
-        usage="<channel name> <webhook name>",
-        help="Removes a Twitch channel from being tracked in the given Webhook."
-    )
+    @twitch.command(name="remove")
     @commands.has_permissions(administrator=True)
     async def remove_twitch_channel(self, context, channel, webhook_name):
         """
@@ -793,12 +763,7 @@ class TwitchCog(commands.Cog):
             await context.send(self.user_strings["channel_not_tracked"].format(name=channel, webhook=webhook_name))
             return
 
-    @twitch.command(
-        name="list",
-        usage="[webhook name]",
-        help="Shows a list of all the currently tracked Twitch accounts and their custom messages for the given Webhook. "
-        "If no Webhook name is given, it shows the information for all Twitch Webhooks."
-    )
+    @twitch.command(name="list")
     @commands.has_permissions(administrator=True)
     async def get_accounts_tracked(self, context, webhook_name=None):
         """
@@ -822,7 +787,7 @@ class TwitchCog(commands.Cog):
             embed = self.get_webhook_channels_as_embed(hook, self._twitch_app.hooks.get(hook).get("name"))
             await context.send(embed=embed)
 
-    @twitch.command(name="webhooks", help="Shows a list of the current Webhooks for the Twitch Cog.")
+    @twitch.command(name="webhooks")
     @commands.has_permissions(administrator=True)
     async def get_current_webhooks(self, context):
         """
@@ -839,12 +804,7 @@ class TwitchCog(commands.Cog):
         string = ", ".join(self._twitch_app.hooks.get(x).get("name") for x in guild_hooks)
         await context.send(self.user_strings["current_webhooks"].format(webhooks=string, prefix=WEBHOOK_PREFIX))
 
-    @twitch.command(
-        name="setmessage",
-        usage="<channel name> <webhook name> [message]",
-        help="Sets the custom message of a Twitch channel for the given Webhook. "
-        "Can be left empty if the custom message is to be removed. "
-    )
+    @twitch.command(name="setmessage")
     @commands.has_permissions(administrator=True)
     async def set_channel_message(self, context, channel, webhook_name, custom_message=None):
         """
@@ -888,12 +848,7 @@ class TwitchCog(commands.Cog):
             await context.send(self.user_strings["channel_not_tracked"].format(name=channel, webhook=webhook_name))
             return
 
-    @twitch.command(
-        name="getmessage",
-        usage="<channel name> [webhook name]",
-        help="Gets the currently set custom message for a Twitch channel for the given Webhook."
-        "If no Webhook name is given, it shows a list of all the custom messages for the Webhooks the channel is tracked in."
-    )
+    @twitch.command(name="getmessage")
     async def get_channel_message(self, context, channel, webhook_name=None):
         """
         Gets the custom channel message for a Webhook. If no Webhook name is given, get all the custom messages.
@@ -930,11 +885,7 @@ class TwitchCog(commands.Cog):
 
         await context.send(string)
 
-    @twitch.command(
-        name="preview",
-        usage="<channel name> <webhook name>",
-        help="Shows a preview of the live notification for a given channel for the given Webhook."
-    )
+    @twitch.command(name="preview")
     async def get_channel_preview(self, context, channel, webhook_name):
         """
         Gets a preview embed for a given Twitch channel in a given Webhook.

--- a/src/esportsbot/cogs/TwitterCog.py
+++ b/src/esportsbot/cogs/TwitterCog.py
@@ -310,22 +310,11 @@ class TwitterCog(commands.Cog):
             guild_info[str(item.twitter_user_id)].add(item.guild_id)
         return guild_info
 
-    @commands.group(
-        name="twitter",
-        help="Commands that are used to post twitter status updates to channels.",
-        invoke_without_command=True
-    )
+    @commands.group(name="twitter", invoke_without_command=True)
     async def command_group(self, context: commands.Context):
         pass
 
-    @command_group.command(
-        name="hook",
-        alias=["addtwitterhook",
-               "create-hook"],
-        usage="[text channel] [hook name]",
-        help="Creates a new Discord Webhook in a server. If the parameter for hook name is filled, "
-        "the channel parameter must also be filled."
-    )
+    @command_group.command(name="hook", alias=["addtwitterhook", "create-hook"])
     async def twitterhook(self, ctx: commands.Context, channel=None, hook_name=None) -> bool:
         """
         Creates a Webhook in a guild. If the channel is specified the Webhook will be bound to that channel
@@ -456,13 +445,7 @@ class TwitterCog(commands.Cog):
 
         return None, None
 
-    @command_group.command(
-        name="remove-hook",
-        alias=["deltwitterhook",
-               "delete-hook"],
-        usage="<hook name>",
-        help="Deletes a Discord Webhook with the name given."
-    )
+    @command_group.command(name="remove-hook", alias=["deltwitterhook", "delete-hook"])
     async def removetwitterhook(self, ctx: discord.ext.commands.Context, name: str) -> bool:
         """
         Deletes a discord Webhook from the calling guild using the name of the Webhook.
@@ -494,11 +477,7 @@ class TwitterCog(commands.Cog):
         await ctx.send(self.user_strings["webhook_deleted"].format(name=hook_info.get("name"), hook_id=h_id))
         return True
 
-    @command_group.command(
-        name="add",
-        usage="<account handle>",
-        help="Starts tracking a given twitter account in this server."
-    )
+    @command_group.command(name="add")
     async def addtwitter(self, ctx: discord.ext.commands.Context, account: str) -> bool:
         """
         Adds a new account to be tracked in the guild from which the command was called.
@@ -550,11 +529,7 @@ class TwitterCog(commands.Cog):
             await ctx.send(self.user_strings["account_missing_error"].format(account=account, operation="add"))
             return False
 
-    @command_group.command(
-        name="remove",
-        usage="<account handle>",
-        help="Stops tracking a given twitter account in this server."
-    )
+    @command_group.command(name="remove")
     async def removetwitter(self, ctx: discord.ext.commands.Context, account: str) -> bool:
         """
         Removes an account from the guild from which the command was called.
@@ -603,12 +578,7 @@ class TwitterCog(commands.Cog):
             await ctx.send(self.user_strings["account_missing_error".format(account=account, operation="remove")])
             return False
 
-    @command_group.command(
-        name="list",
-        alias=["accounts",
-               "get-all"],
-        help="Gets a list of the currently tracked accounts in this server."
-    )
+    @command_group.command(name="list", alias=["accounts", "get-all"])
     async def gettwitters(self, ctx: discord.ext.commands.Context):
         """
         Gets the list of Twitter handles that are currently tracked in the guild that called the command.

--- a/src/esportsbot/cogs/VoicemasterCog.py
+++ b/src/esportsbot/cogs/VoicemasterCog.py
@@ -52,7 +52,7 @@ class VoicemasterCog(commands.Cog):
             DBGatewayActions().create(slave_db_entry)
             await member.move_to(slave_channel)
 
-    @commands.command(name="setvmparents")
+    @commands.command(name="setvmparent")
     @commands.has_permissions(administrator=True)
     async def setvmmaster(self, ctx, given_channel_id=None):
         is_a_valid_id = given_channel_id and given_channel_id.isdigit() and len(given_channel_id) == 18

--- a/src/esportsbot/cogs/VoicemasterCog.py
+++ b/src/esportsbot/cogs/VoicemasterCog.py
@@ -52,11 +52,7 @@ class VoicemasterCog(commands.Cog):
             DBGatewayActions().create(slave_db_entry)
             await member.move_to(slave_channel)
 
-    @commands.command(
-        name="setvmparent",
-        usage="<channel_id>",
-        help="Sets the passed voice channel to a Voicemaster master channel"
-    )
+    @commands.command(name="setvmparents")
     @commands.has_permissions(administrator=True)
     async def setvmmaster(self, ctx, given_channel_id=None):
         is_a_valid_id = given_channel_id and given_channel_id.isdigit() and len(given_channel_id) == 18
@@ -97,7 +93,7 @@ class VoicemasterCog(commands.Cog):
             else:
                 await ctx.channel.send(self.STRINGS['error_bad_id_format'])
 
-    @commands.command(name="getvmparents", usage="", help="Gets all of the Voicemaster master channels from the server")
+    @commands.command(name="getvmparents")
     @commands.has_permissions(administrator=True)
     async def getvmmasters(self, ctx):
         master_vm_exists = DBGatewayActions().list(Voicemaster_master, guild_id=ctx.author.guild.id)
@@ -110,11 +106,7 @@ class VoicemasterCog(commands.Cog):
         else:
             await ctx.channel.send(self.STRINGS['error_no_vms'])
 
-    @commands.command(
-        name="removevmparent",
-        usage="<channel_id>",
-        help="Removes the passed voice channel from being Voicemaster master channel"
-    )
+    @commands.command(name="removevmparent")
     @commands.has_permissions(administrator=True)
     async def removevmmaster(self, ctx, given_channel_id=None):
         if given_channel_id:
@@ -145,7 +137,7 @@ class VoicemasterCog(commands.Cog):
         else:
             await ctx.channel.send(self.STRINGS['error_no_id'])
 
-    @commands.command(name="removeallparents", usage="", help="Removes all the Voicemaster master channels from the server")
+    @commands.command(name="removeallparents")
     @commands.has_permissions(administrator=True)
     async def removeallmasters(self, ctx):
         all_vm_masters = DBGatewayActions().list(Voicemaster_master, guild_id=ctx.author.guild.id)
@@ -160,7 +152,7 @@ class VoicemasterCog(commands.Cog):
             },
         )
 
-    @commands.command(name="removeallchildren", usage="", help="Deletes all Voicemaster slave channels from the server")
+    @commands.command(name="removeallchildren")
     @commands.has_permissions(administrator=True)
     async def killallslaves(self, ctx):
         all_vm_slaves = DBGatewayActions().list(Voicemaster_slave, guild_id=ctx.author.guild.id)
@@ -178,7 +170,7 @@ class VoicemasterCog(commands.Cog):
             },
         )
 
-    @commands.command(name="lockvm", aliases=["lock"], usage="", help="Locks the Voicemaster slave that you are currently in")
+    @commands.command(name="lockvm", aliases=["lock"])
     async def lockvm(self, ctx):
         if not ctx.author.voice:
             await ctx.channel.send(self.STRINGS['error_not_in_slave'])
@@ -210,12 +202,7 @@ class VoicemasterCog(commands.Cog):
         else:
             await ctx.channel.send(self.STRINGS['error_not_in_slave'])
 
-    @commands.command(
-        name="unlockvm",
-        aliases=["unlock"],
-        usage="",
-        help="Unlocks the Voicemaster slave that you are currently in"
-    )
+    @commands.command(name="unlockvm", aliases=["unlock"])
     async def unlockvm(self, ctx):
         if not ctx.author.voice:
             await ctx.channel.send(self.STRINGS['error_not_in_slave'])

--- a/src/esportsbot/cogs/VoicemasterCog.py
+++ b/src/esportsbot/cogs/VoicemasterCog.py
@@ -39,13 +39,21 @@ class VoicemasterCog(commands.Cog):
                     DBGatewayActions().update(vm_slave)
 
         if after.channel and get_whether_in_vm_master(after.channel.guild.id, after.channel.id):
-            slave_channel = await member.guild.create_voice_channel(f"{member.display_name}'s VC", category=after.channel.category)
-            slave_db_entry = Voicemaster_slave(guild_id=member.guild.id, channel_id=slave_channel.id, owner_id=member.id, locked=False)
+            slave_channel = await member.guild.create_voice_channel(
+                f"{member.display_name}'s VC",
+                category=after.channel.category
+            )
+            slave_db_entry = Voicemaster_slave(
+                guild_id=member.guild.id,
+                channel_id=slave_channel.id,
+                owner_id=member.id,
+                locked=False
+            )
             DBGatewayActions().create(slave_db_entry)
             await member.move_to(slave_channel)
 
     @commands.command(
-        name="setvmmaster",
+        name="setvmparent",
         usage="<channel_id>",
         help="Sets the passed voice channel to a Voicemaster master channel"
     )
@@ -89,7 +97,7 @@ class VoicemasterCog(commands.Cog):
             else:
                 await ctx.channel.send(self.STRINGS['error_bad_id_format'])
 
-    @commands.command(name="getvmmasters", usage="", help="Gets all of the Voicemaster master channels from the server")
+    @commands.command(name="getvmparents", usage="", help="Gets all of the Voicemaster master channels from the server")
     @commands.has_permissions(administrator=True)
     async def getvmmasters(self, ctx):
         master_vm_exists = DBGatewayActions().list(Voicemaster_master, guild_id=ctx.author.guild.id)
@@ -103,7 +111,7 @@ class VoicemasterCog(commands.Cog):
             await ctx.channel.send(self.STRINGS['error_no_vms'])
 
     @commands.command(
-        name="removevmmaster",
+        name="removevmparent",
         usage="<channel_id>",
         help="Removes the passed voice channel from being Voicemaster master channel"
     )
@@ -137,7 +145,7 @@ class VoicemasterCog(commands.Cog):
         else:
             await ctx.channel.send(self.STRINGS['error_no_id'])
 
-    @commands.command(name="removeallmasters", usage="", help="Removes all the Voicemaster master channels from the server")
+    @commands.command(name="removeallparents", usage="", help="Removes all the Voicemaster master channels from the server")
     @commands.has_permissions(administrator=True)
     async def removeallmasters(self, ctx):
         all_vm_masters = DBGatewayActions().list(Voicemaster_master, guild_id=ctx.author.guild.id)
@@ -152,7 +160,7 @@ class VoicemasterCog(commands.Cog):
             },
         )
 
-    @commands.command(name="killallslaves", usage="", help="Deletes all Voicemaster slave channels from the server")
+    @commands.command(name="removeallchildren", usage="", help="Deletes all Voicemaster slave channels from the server")
     @commands.has_permissions(administrator=True)
     async def killallslaves(self, ctx):
         all_vm_slaves = DBGatewayActions().list(Voicemaster_slave, guild_id=ctx.author.guild.id)

--- a/src/esportsbot/cogs/VotingCog.py
+++ b/src/esportsbot/cogs/VotingCog.py
@@ -9,7 +9,6 @@ from esportsbot.db_gateway import DBGatewayActions
 from esportsbot.models import Voting_menus
 
 DELETE_ON_CREATE = os.getenv("DELETE_VOTING_CREATION", "FALSE").lower() == "true"
-MAKE_POLL_README = "#votes-make-poll-title-emoji-description"
 
 
 class VotingCog(commands.Cog):
@@ -82,7 +81,7 @@ class VotingCog(commands.Cog):
         self.db.delete(db_item)
         await menu.message.delete()
 
-    @commands.group(name="votes", help="Create reaction menus that can be used as a poll.")
+    @commands.group(name="votes")
     async def command_group(self, context: commands.Context):
         """
         The command group used to make all commands sub-commands .
@@ -90,13 +89,7 @@ class VotingCog(commands.Cog):
         """
         pass
 
-    @command_group.command(
-        name="make-poll",
-        usage="<title> \n[options]\n...",
-        help="Creates a new poll for users to vote on. "
-        "Each of the options to vote on are put on a new line, more help regarding this command can be found here: "
-        f"https://github.com/FragSoc/esports-bot{MAKE_POLL_README}."
-    )
+    @command_group.command(name="make-poll")
     async def create_poll_menu(self, context: commands.Context):
         """
         Creates a new poll with the options provided in the command .
@@ -124,13 +117,7 @@ class VotingCog(commands.Cog):
         if DELETE_ON_CREATE:
             await context.message.delete()
 
-    @command_group.command(
-        name="add-option",
-        usage="<menu id> <emoji> <description>",
-        help="Adds another option to an existing poll.",
-        aliases=["add",
-                 "aoption"]
-    )
+    @command_group.command(name="add-option", aliases=["add", "aoption"])
     async def add_poll_option(self, context: commands.Context, menu_id: int, emoji):
         """
         Adds another poll option to the given poll .
@@ -150,13 +137,7 @@ class VotingCog(commands.Cog):
         await voting_menu.update_message()
         self.add_or_update_db(voting_menu.id)
 
-    @command_group.command(
-        name="remove-option",
-        usage="<menu id> <emoji>",
-        help="Removes a poll option from an existing poll",
-        aliases=["remove",
-                 "roption"]
-    )
+    @command_group.command(name="remove-option", aliases=["remove", "roption"])
     async def remove_poll_option(self, context: commands.Context, menu_id: int, emoji):
         """
         Remove an option from a poll .
@@ -173,13 +154,7 @@ class VotingCog(commands.Cog):
         await voting_menu.update_message()
         self.add_or_update_db(voting_menu.id)
 
-    @command_group.command(
-        name="delete-poll",
-        usage="<menu id>",
-        help="Deletes a given role reaction menu.",
-        aliases=["delete",
-                 "del"]
-    )
+    @command_group.command(name="delete-poll",  aliases=["delete", "del"])
     async def delete_poll(self, context: commands.Context, menu_id: int):
         """
         Delete a poll .
@@ -197,7 +172,7 @@ class VotingCog(commands.Cog):
         self.db.delete(db_item)
         await context.reply(self.user_strings["delete_menu"].format(menu_id=voting_menu.id))
 
-    @command_group.command(name="end-poll", usage="<menu id>", help="Finishes a poll.", aliases=["finish", "complete", "end"])
+    @command_group.command(name="end-poll", aliases=["finish", "complete", "end"])
     async def finish_poll(self, context: commands.Context, menu_id: int):
         """
         Finishes a poll to get results and stop new votes from coming in .
@@ -211,14 +186,7 @@ class VotingCog(commands.Cog):
 
         await self.finalise_poll(voting_menu)
 
-    @command_group.command(
-        name="reset-poll",
-        usage="<menu id>",
-        help="Removes all user reactions from the poll.",
-        aliases=["reset",
-                 "clear",
-                 "restart"]
-    )
+    @command_group.command(name="reset-poll", aliases=["reset", "clear", "restart"])
     async def reset_poll_votes(self, context: commands.Context, menu_id: int):
         """
         Reset the current votes on a poll .

--- a/src/esportsbot/lib/CustomHelpCommand.py
+++ b/src/esportsbot/lib/CustomHelpCommand.py
@@ -54,6 +54,9 @@ class CustomHelpCommand(HelpCommand):
         :param embed: THe embed to add the field to.
         :param command: The command to add the help field of.
         """
+        if command.hidden and not self.context.author.guild_permissions.administrator:
+            return
+
         checks = command.checks
         checks_to_add = []
         for check in checks:

--- a/src/esportsbot/lib/CustomHelpCommand.py
+++ b/src/esportsbot/lib/CustomHelpCommand.py
@@ -179,7 +179,7 @@ class CustomHelpCommand(HelpCommand):
         Send the help for a given cog.
         :param cog: The cog to get the help about.
         """
-        await self.context.send(embed=self.get_cog_help(cog, cog.get_commands()))
+        await self.context.send(embed=await self.get_cog_help(cog, cog.get_commands()))
 
 
 class HelpMenu(ReactableMenu):

--- a/src/esportsbot/lib/CustomHelpCommand.py
+++ b/src/esportsbot/lib/CustomHelpCommand.py
@@ -1,0 +1,143 @@
+from discord import Embed, Colour
+from discord.ext.commands import HelpCommand, MissingPermissions
+
+from esportsbot.DiscordReactableMenus.EmojiHandler import MultiEmoji
+from esportsbot.DiscordReactableMenus.ReactableMenu import ReactableMenu
+
+
+class CustomHelpCommand(HelpCommand):
+    def __init__(self, **options):
+        super().__init__(**options)
+
+    # !help
+    async def send_bot_help(self, mapping):
+        embeds = []
+        for cog, commands in mapping.items():
+            embed = await self.get_cog_help(cog, commands)
+            if len(embed.fields) > 0:
+                embeds.append(embed)
+
+        help_menu = HelpMenu(embeds=embeds)
+        await help_menu.finalise_and_send(self.context.bot, self.context.channel)
+
+    async def get_cog_help(self, cog, commands):
+        embed = Embed(title=getattr(cog, "qualified_name", "No Category"), description="​", colour=Colour.random())
+        for command in commands:
+            await self.add_command_field(embed, command)
+
+        embed.set_footer(text="For more help go to https://github.com/FragSoc/esports-bot")
+
+        return embed
+
+    async def add_command_field(self, embed, command):
+        checks = command.checks
+        for check in checks:
+            if check.__name__ != "predicate":
+                command.remove_check(check)
+
+        try:
+            await command.can_run(self.context)
+        except MissingPermissions:
+            return
+
+        name = command.name
+        if command.full_parent_name:
+            name = command.full_parent_name + " " + name
+
+        value = ""
+        if command.help:
+            value += f"• {command.help}"
+
+        aliases = command.aliases
+        if aliases:
+            alias_string = str(aliases).replace("]", "").replace("[", "").replace("'", "")
+            value += f"\n• Aliases: {alias_string}"
+
+        value += f"\n• Help command: {self.clean_prefix}help {name}\n​"
+
+        embed.add_field(name=f"**{self.clean_prefix}{name}**", value=value, inline=False)
+
+    # !help <command>
+    async def send_command_help(self, command):
+        name = command.name
+        if command.full_parent_name:
+            name = f"{command.full_parent_name} {name}"
+        title = f"Showing help for — {self.clean_prefix}{name}"
+        description = "<No description>" if not command.help else command.help
+        embed = Embed(title=title, description=description, colour=Colour.random())
+        usage = "<No parameters>" if not command.usage else f"{self.clean_prefix}{name} {command.usage}"
+        embed.add_field(name=f"Usage:", value=usage, inline=False)
+        embed.add_field(
+            name="​",
+            value="• Parameters with `<>` around them are required parameters.\n"
+            "• Parameters with `[]` are optional parameters.\n"
+            "• The brackets are not required when executing the command."
+        )
+        embed.set_footer(text="For more help go to https://github.com/FragSoc/esports-bot")
+        await self.context.send(embed=embed)
+
+    # !help <group>
+    async def send_group_help(self, group):
+        name = group.name
+        if group.full_parent_name:
+            name = f"{group.full_parent_name} {name}"
+        title = f"Showing help for — {self.clean_prefix}{name}"
+        description = "​" if not group.help else f"{group.help}\n​"
+        embed = Embed(title=title, description=description, colour=Colour.random())
+        for command in group.commands:
+            await self.add_command_field(embed, command)
+        embed.set_footer(text="For more help go to https://github.com/FragSoc/esports-bot")
+        await self.context.send(embed=embed)
+
+    # !help <cog>
+    async def send_cog_help(self, cog):
+        await self.context.send(embed=self.get_cog_help(cog, cog.get_commands()))
+
+
+class HelpMenu(ReactableMenu):
+    def __init__(self, **kwargs):
+        if kwargs.get("add_func") is None:
+            kwargs["add_func"] = self.react_add_func
+        super().__init__(**kwargs)
+        self.embeds = kwargs.get("embeds", None)
+        if self.embeds is None:
+            raise ValueError("No embeds supplied to the help menu!")
+
+        self.auto_enable = True
+        self.show_ids = False
+        self.current_index = 0
+        self.max_index = len(self.embeds)
+        self.add_option("⬅", "-1")
+        self.add_option("➡", "+1")
+        self.add_option("❌", "exit")
+
+    async def react_add_func(self, payload):
+        emoji_triggered = payload.emoji
+        channel_id: int = payload.channel_id
+        message_id: int = payload.message_id
+        guild = self.message.guild
+
+        if emoji_triggered not in self:
+            channel = guild.get_channel(channel_id)
+            message = await channel.fetch_message(message_id)
+            await message.clear_reaction(emoji_triggered)
+            return False
+
+        formatted_emoji = MultiEmoji(emoji_triggered)
+        option = self.options.get(formatted_emoji.emoji_id).get("descriptor")
+        try:
+            self.current_index += int(option)
+            if self.current_index >= self.max_index:
+                self.current_index = 0
+            if self.current_index < 0:
+                self.current_index = self.max_index - 1
+
+            await self.update_message()
+            channel = guild.get_channel(channel_id)
+            message = await channel.fetch_message(message_id)
+            await message.remove_reaction(emoji_triggered, payload.member)
+        except ValueError:
+            await self.message.delete()
+
+    def generate_embed(self) -> Embed:
+        return self.embeds[self.current_index]

--- a/src/esportsbot/lib/CustomHelpCommand.py
+++ b/src/esportsbot/lib/CustomHelpCommand.py
@@ -6,7 +6,6 @@ from esportsbot.DiscordReactableMenus.ReactableMenu import ReactableMenu
 
 
 class CustomHelpCommand(HelpCommand):
-
     async def send_bot_help(self, mapping):
         """
         This function runs when the bare `help` command is run without any groups or commands specified.

--- a/src/esportsbot/lib/CustomHelpCommand.py
+++ b/src/esportsbot/lib/CustomHelpCommand.py
@@ -6,12 +6,15 @@ from esportsbot.DiscordReactableMenus.ReactableMenu import ReactableMenu
 
 
 class CustomHelpCommand(HelpCommand):
-    def __init__(self, **options):
-        super().__init__(**options)
 
-    # !help
     async def send_bot_help(self, mapping):
+        """
+        This function runs when the bare `help` command is run without any groups or commands specified.
+        :param mapping: The mapping of Cogs -> Union [Command Groups, Commands]
+        """
         embeds = []
+        # Get an embed for each cog that has more than 1 field. Some cogs may have no fields if the user requesting
+        # does not have permissions to use a given command. Eg: Command needs admin permissions and user is not an admin
         for cog, commands in mapping.items():
             embed = await self.get_cog_help(cog, commands)
             if len(embed.fields) > 0:
@@ -21,6 +24,12 @@ class CustomHelpCommand(HelpCommand):
         await help_menu.finalise_and_send(self.context.bot, self.context.channel)
 
     async def get_cog_help(self, cog, commands):
+        """
+        Gets the help embed for a given cog and its commands.
+        :param cog: The cog to get the help embed of.
+        :param commands: The commands and command groups in the given cog.
+        :return: An embed for the cog.
+        """
         embed = Embed(title=getattr(cog, "qualified_name", "No Category"), description="​", colour=Colour.random())
         for command in commands:
             await self.add_command_field(embed, command)
@@ -30,12 +39,21 @@ class CustomHelpCommand(HelpCommand):
         return embed
 
     async def add_command_field(self, embed, command):
+        """
+        Adds the embed field for a given command to an embed. If the command does not pass the checks, it is not added.
+        Eg: Command needs admin but user is not an admin.
+        :param embed: THe embed to add the field to.
+        :param command: The command to add the help field of.
+        """
         checks = command.checks
         for check in checks:
+            # Remove any custom checks. Checks such as admin will not be removed.
             if check.__name__ != "predicate":
                 command.remove_check(check)
 
         try:
+            # For some reason instead of returning False, this will just raise an error if the user is not able to run
+            # the command.
             await command.can_run(self.context)
         except MissingPermissions:
             return
@@ -57,14 +75,20 @@ class CustomHelpCommand(HelpCommand):
 
         embed.add_field(name=f"**{self.clean_prefix}{name}**", value=value, inline=False)
 
-    # !help <command>
     async def send_command_help(self, command):
+        """
+        Runs when the help command is run with a parameter that is a command. This can be a subcommand of a group or a
+        command that is not in a group.
+        :param command: The command to get the help information of.
+        """
         name = command.name
         if command.full_parent_name:
             name = f"{command.full_parent_name} {name}"
+
         title = f"Showing help for — {self.clean_prefix}{name}"
         description = "<No description>" if not command.help else command.help
         embed = Embed(title=title, description=description, colour=Colour.random())
+
         usage = "<No parameters>" if not command.usage else f"{self.clean_prefix}{name} {command.usage}"
         embed.add_field(name=f"Usage:", value=usage, inline=False)
         embed.add_field(
@@ -73,24 +97,34 @@ class CustomHelpCommand(HelpCommand):
             "• Parameters with `[]` are optional parameters.\n"
             "• The brackets are not required when executing the command."
         )
+
         embed.set_footer(text="For more help go to https://github.com/FragSoc/esports-bot")
         await self.context.send(embed=embed)
 
-    # !help <group>
     async def send_group_help(self, group):
+        """
+        Runs when the help command is run with a parameter that is a command group.
+        :param group: The command group to send the help information about.
+        """
         name = group.name
         if group.full_parent_name:
             name = f"{group.full_parent_name} {name}"
+
         title = f"Showing help for — {self.clean_prefix}{name}"
         description = "​" if not group.help else f"{group.help}\n​"
         embed = Embed(title=title, description=description, colour=Colour.random())
+
         for command in group.commands:
             await self.add_command_field(embed, command)
+
         embed.set_footer(text="For more help go to https://github.com/FragSoc/esports-bot")
         await self.context.send(embed=embed)
 
-    # !help <cog>
     async def send_cog_help(self, cog):
+        """
+        Send the help for a given cog.
+        :param cog: The cog to get the help about.
+        """
         await self.context.send(embed=self.get_cog_help(cog, cog.get_commands()))
 
 
@@ -112,6 +146,10 @@ class HelpMenu(ReactableMenu):
         self.add_option("❌", "exit")
 
     async def react_add_func(self, payload):
+        """
+        The function to run when the help menu is reacted to.
+        :param payload: The payload information of the reaction event.
+        """
         emoji_triggered = payload.emoji
         channel_id: int = payload.channel_id
         message_id: int = payload.message_id
@@ -126,6 +164,8 @@ class HelpMenu(ReactableMenu):
         formatted_emoji = MultiEmoji(emoji_triggered)
         option = self.options.get(formatted_emoji.emoji_id).get("descriptor")
         try:
+            # Bit scuffed, but if the conversion to an int fails, the "exit" option was chosen and therefore just delete
+            # the help menu.
             self.current_index += int(option)
             if self.current_index >= self.max_index:
                 self.current_index = 0

--- a/src/esportsbot/lib/CustomHelpCommand.py
+++ b/src/esportsbot/lib/CustomHelpCommand.py
@@ -55,10 +55,12 @@ class CustomHelpCommand(HelpCommand):
         :param command: The command to add the help field of.
         """
         checks = command.checks
+        checks_to_add = []
         for check in checks:
             # Remove any custom checks. Checks such as admin will not be removed.
             if check.__name__ != "predicate":
                 command.remove_check(check)
+                checks_to_add.append(check)
 
         try:
             # For some reason instead of returning False, this will just raise an error if the user is not able to run
@@ -66,6 +68,9 @@ class CustomHelpCommand(HelpCommand):
             await command.can_run(self.context)
         except MissingPermissions:
             return
+
+        for check in checks_to_add:
+            command.add_check(check)
 
         fully_qualified_name = command.name
         if command.full_parent_name:

--- a/src/esportsbot/lib/CustomHelpCommand.py
+++ b/src/esportsbot/lib/CustomHelpCommand.py
@@ -76,7 +76,7 @@ class CustomHelpCommand(HelpCommand):
         # name = <prefix><fully qualified name>
         # value = Short help string \n Alias String \n Help command string
 
-        help_dict = self.help_strings.get(fully_qualified_name.replace(" ", "_"))
+        help_dict = self.help_strings.get(fully_qualified_name.replace(" ", "_").replace("-", "_"))
         name = self.help_strings["usage_string"].format(prefix=self.clean_prefix, fqn=fully_qualified_name)
         if not help_dict:
             # If the command is missing help string definition in the user_strings file, try and default to the defined
@@ -115,7 +115,7 @@ class CustomHelpCommand(HelpCommand):
         title = self.help_strings["embed_title"].format(prefix=self.clean_prefix, fqn=fully_qualified_name)
         usage = self.help_strings["usage_string"].format(prefix=self.clean_prefix, fqn=fully_qualified_name)
 
-        help_dict = self.help_strings.get(fully_qualified_name.replace(" ", "_"))
+        help_dict = self.help_strings.get(fully_qualified_name.replace(" ", "_").replace("-", "_"))
         if not help_dict:
             short = command.help if command.help else self.help_strings["missing_help_string"]
             long_string = command.description if command.description else ""
@@ -148,7 +148,7 @@ class CustomHelpCommand(HelpCommand):
         fully_qualified_name = fully_qualified_name.strip()
 
         title = self.help_strings["embed_title"].format(prefix=self.clean_prefix, fqn=fully_qualified_name)
-        help_dict = self.help_strings.get(fully_qualified_name.replace(" ", "_"))
+        help_dict = self.help_strings.get(fully_qualified_name.replace(" ", "_").replace("-", "_"))
         if not help_dict:
             description = "​" if not group.help else group.help
         else:

--- a/src/esportsbot/lib/client.py
+++ b/src/esportsbot/lib/client.py
@@ -99,6 +99,7 @@ def instance() -> EsportsBot:
                       "!"),
             "esportsbot/user_strings.toml",
             intents=intents,
-            help_command=CustomHelpCommand()
+            help_command=None
         )
+        _instance.help_command = CustomHelpCommand(help_strings=_instance.STRINGS["help"])
     return _instance

--- a/src/esportsbot/lib/client.py
+++ b/src/esportsbot/lib/client.py
@@ -3,6 +3,7 @@ from discord.ext import commands
 from discord import Intents, Embed, Message, Colour
 from esportsbot.DiscordReactableMenus.EmojiHandler import MultiEmoji
 from esportsbot.db_gateway import DBGatewayActions
+from esportsbot.lib.CustomHelpCommand import CustomHelpCommand
 from esportsbot.models import Guild_info
 from typing import Dict, MutableMapping, Union
 from datetime import datetime
@@ -93,5 +94,11 @@ def instance() -> EsportsBot:
     if _instance is None:
         intents = Intents.default()
         intents.members = True
-        _instance = EsportsBot(os.getenv("COMMAND_PREFIX", "!"), "esportsbot/user_strings.toml", intents=intents)
+        _instance = EsportsBot(
+            os.getenv("COMMAND_PREFIX",
+                      "!"),
+            "esportsbot/user_strings.toml",
+            intents=intents,
+            help_command=CustomHelpCommand()
+        )
     return _instance

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -275,6 +275,36 @@ help_string = "Stops the current logging channel from being active."
 description = "The current logging channel will become a regular channel and logging events will no longer be posted to the channel."
 readme_url = "https://github.com/FragSoc/esports-bot#removelogchannel"
 
+[help.twitter]
+help_string = "This is the command group used to manage posting Twitter updates to discord channels. Use the help command for this command to see a list of all the Twitter related commands."
+readme_url = "https://github.com/FragSoc/esports-bot#twitter-integration"
+
+[help.twitter_hook]
+help_string = "Create a new Discord Webhook for Twitter."
+description = "This will create a new Discord Webhook that can then be used to post Twitter updates to the channel that the webhook is bound to. If you want a specific name you must include the channel parameter."
+usage = "[optional: channel mention] [optional: hook name]"
+readme_url = "https://github.com/FragSoc/esports-bot#twitter-hook-optional-channel-mention-optional-hook-name"
+
+[help.twitter_remove_hook]
+help_string = "Deletes an existing Discord Webhook for Twitter."
+description = "This will delete the given Discord Webhook. You do not need to include the Twitter Webhook prefix, but the Discord Webhook you are wanting to delete must be one that has the Twitter prefix in it. Once delete, Twitter updates will no longer be posted to that channel."
+usage = "<hook name>"
+readme_url = "https://github.com/FragSoc/esports-bot#twitter-remove-hook-hook-name"
+
+[help.twitter_add]
+help_string = "Adds a Twitter account to be tracked."
+usage = "<account handle>"
+readme_url = "https://github.com/FragSoc/esports-bot#twitter-add-twitter-handle"
+
+[help.twitter_remove]
+help_string = "Stops tracking a Twitter account."
+usage = "<account handle>"
+readme_url = "https://github.com/FragSoc/esports-bot#twitter-remove-twitter-handle"
+
+[help.twitter_list]
+help_string = "Lists all the Twitter accounts currently tracked."
+readme_url = "https://github.com/FragSoc/esports-bot#twitter-list"
+
 [logging]
 channel_set = "Logging channel has been set to <#{channel_id!s}>"
 channel_set_already = "Logging channel already set to this channel"

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -103,11 +103,11 @@ description = "This will just stop the channel from processing song requests, th
 readme_url = "https://github.com/FragSoc/esports-bot#musicadmin-remove"
 
 [help.pingme]
-help_string = "This is a command group used to create custom roles that have ping cooldown timers."
+help_string = "This is a command group used to create custom roles that have ping cooldown timers. Use the help command to see a list of all `pingme` subcommands."
 readme_url = "https://github.com/FragSoc/esports-bot#pingable-roles"
 
 [help.pingme_settings]
-help_string = "This is a command group used to manage the default settings for pingable roles in this server. These commands require the `administrator` permission in this server."
+help_string = "This is a command group used to manage the default settings for pingable roles in this server. These commands require the `administrator` permission in this server. Use the help command to see a list of all subcommands."
 readme_url = "https://github.com/FragSoc/esports-bot#pingable-roles"
 
 [help.pingme_settings_get_settings]

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -3,16 +3,19 @@ command_error_required_arguments = "Arguments are required for this command! See
 guild_leave = "Left the guild: {guild_name}"
 
 [help]
-command_footer = "• Parameters with `<>` around them are required parameters.\n• Parameters with `[]` are optional parameters.\n• The brackets are not required when executing the command."
-embed_footer = "For more help go to https://github.com/FragSoc/esports-bot"
-command_help = "• Help Command: {help_string}"
-command_alias = "• Aliases: {aliases}"
+missing_help_string = ":warning: Missing help string :warning:"
 empty_category = "No Category"
-embed_title = "Showing help for Showing help for — {prefix}{name}"
-usage_string = "{prefix}{fqn}"
+embed_title = "Showing help for — {prefix}{fqn}"
+embed_footer = "For more help go to https://github.com/FragSoc/esports-bot"
+usage_string = "{prefix}{fqn} "
+command_help_short = "• {help_string}"
+command_description = "{short_string} \n\n {long_string}"
+command_help = "• Help Command: {prefix}help {fqn}"
+command_alias = "• Aliases: {aliases}"
+command_footer = "• Parameters with `<>` around them are required parameters.\n• Parameters with `[]` are optional parameters.\n• The brackets are not required when executing the command."
 
 [help.music]
-help_string = "This is a command group for controlling music playback. All subcommands of this one can only be run in the music channel. Just executing this command will not do anything, use `{prefix}help music` to find a list of all the music commands."
+help_string = "This is a command group for controlling music playback. All subcommands of this one can only be run in the music channel. Just executing this command will not do anything, use the help command for this command to see the list of all music commands."
 readme_url = "https://github.com/FragSoc/esports-bot#music-bot"
 
 [help.music_queue]

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -432,6 +432,62 @@ description = "Resets a poll to have no votes on it. You must be the creator of 
 usage = "<poll menu ID>"
 readme_url = "https://github.com/FragSoc/esports-bot#votes-reset-poll-menu-id"
 
+[help.twitch]
+help_string = "This is a command group used to control the managing of posting Twitch live notifications. Use the help command of this command to see available subcommands."
+readme_url = "https://github.com/FragSoc/esports-bot#twitch-integration"
+
+[help.twitch_createhook]
+help_string = "Create a new Discord Webhook for Twitch notifications."
+description = "Creates a Webhook with the given name that can be used to post live notifications of specific Twitch channels to the specific Discord text channel the Webhook is bound to."
+usage = "<channel mention> <hook name>"
+readme_url = "https://github.com/FragSoc/esports-bot#twitch-createhook-optional-channel_mention-optional-hook-name"
+
+[help.twitch_deletehook]
+help_string = "Delete an existing Discord Webhook for Twitch notifications."
+description = "Deletes a Webhook used for Twitch notifications. The name provided does not need to include the Twitch Webhook prefix, but it does have to be a Webhook used for Twitch notifications. Any channel that was bound to the given Webhook will no longer have it's live notifications posted to that Discord channel."
+usage = "<hook name>"
+readme_url = "https://github.com/FragSoc/esports-bot#twitch-deletehook-hook-name"
+
+[help.twitch_add]
+help_string = "Adds a Twitch channel to be tracked."
+description = "This will track the given Twitch channel and post its updates to the given discord Webhook. A channel can be bound to many Discord Webhooks. If a custom message is given, it will be used in the live notification and must be surrounded by double quotes."
+usage = "<channel name | channel url> <hook name> [optional: custom message]"
+readme_url = "https://github.com/FragSoc/esports-bot#twitch-add-twitch-handle--twitch-url-optional-custom-message"
+
+[help.twitch_remove]
+help_string = "Stops tracking a Twitch channel."
+description = "This will stop posting updates for the given Twitch channel in the given Webhook's text channel. If the Twitch channel is tracked in other channels, the notifications will still be posted there."
+usage = "<channel name | channel url> <hook name>"
+readme_url = "https://github.com/FragSoc/esports-bot#twitch-remove-twitch-handle"
+
+[help.twitch_list]
+help_string = "Shows a list of the current Discord Webhooks and their tracked channels."
+description = "To only see one Webhooks channels, specify the Webhook name in the command."
+usage = "[optional: hook name]"
+readme_url = "https://github.com/FragSoc/esports-bot#twitch-list"
+
+[help.twitch_webhooks]
+help_string = "Get a list of the current Discord Webhooks for Twitch."
+readme_url = "https://github.com/FragSoc/esports-bot#twitch-webhooks"
+
+[help.twitch_setmessage]
+help_string = "Sets the custom message for a Twitch channel."
+description = "This will set the custom live message for a Twitch channel for a specific Webhook. If the custom message is left empty, the custom message is removed from the live notification."
+usage = "<channel name> <hook name> [optional: custom message]"
+readme_url = "https://github.com/FragSoc/esports-bot#twitch-setmessage-twitch-handle-hook-name-optional-custom-message"
+
+[help.twitch_getmessage]
+help_string = "Get the custom message(s) of a Twitch channel."
+description = "If no hook name is specified, it will return a list of all the custom messages for all the Webhooks the channel is tracked in. Otherwise it will return just the message for the given Webhook."
+usage = "<channel name> [optional: hook name]"
+readme_url = "https://github.com/FragSoc/esports-bot#twitch-getmessage-twitch-handle-optional-hook-name"
+
+[help.twitch_preview]
+help_string = "Preview the live notification for a Twitch channel."
+description = "See what a notification will look like in a given Discord Webhook for the given Twitch channel."
+usage = "<channel name> <hook name>"
+readme_url = "https://github.com/FragSoc/esports-bot#twitch-preview-twitch-handle-hook-name"
+
 [logging]
 channel_set = "Logging channel has been set to <#{channel_id!s}>"
 channel_set_already = "Logging channel already set to this channel"

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -392,6 +392,46 @@ help_string = "Toggle showing IDs at the bottom of role menus."
 description = "This will hide or show the menu ID of all role reaction menus in their footer."
 readme_url = "https://github.com/FragSoc/esports-bot#roles-toggle-ids"
 
+[help.votes]
+help_string = "This is a command group used to create and manage reaction based polls."
+readme_url = "https://github.com/FragSoc/esports-bot#poll-reaction-menus"
+
+[help.votes_make_poll]
+help_string = "Creates a new poll with a given name."
+description = "Creates a new poll with the given name, if the name is more than 1 word long it must be surrounded by double quotes. Each option in the poll must be on a new line and in the format of: <emoji> <description> where if the description is more than 1 word long it must also be surrounded by double quotes. There can be up to 25 options"
+usage = "<title> \n [<emoji> <description>]"
+readme_url = "https://github.com/FragSoc/esports-bot#votes-make-poll-title-emoji-description"
+
+[help.votes_add_option]
+help_string = "Add another poll option to an existing poll."
+description = "The option added must be in the same for as when creating the menu, where if the description is longer than 1 word it must be surrounded by double quotes. You must be the creator of the poll to add an option."
+usage = "<poll menu ID> <emoji> <description>"
+readme_url = "https://github.com/FragSoc/esports-bot#votes-add-option-menu-id-emoji-description"
+
+[help.votes_remove_option]
+help_string = "Remove an existing poll option from a poll."
+description = "Using the emoji to identify the option, remove the option from the poll. You must be the creator of the poll to remove an option."
+usage = "<poll menu ID> <emoji to remove>"
+readme_url = "https://github.com/FragSoc/esports-bot#votes-remove-option-menu-id-emoji"
+
+[help.votes_delete_poll]
+help_string = "Delete a poll."
+description = "This will not get the poll results, but will just remove the message. You must be the creator of the poll to delete it."
+usage = "<poll menu ID>"
+readme_url = "https://github.com/FragSoc/esports-bot#votes-delete-poll-menu-id"
+
+[help.votes_end_poll]
+help_string = "End the voting on a poll."
+description = "This will generate the results of the poll and stop people from voting on the poll. You must be the creator of the poll to end it."
+usage = "<poll menu ID>"
+readme_url = "https://github.com/FragSoc/esports-bot#votes-end-poll-menu-id"
+
+[help.votes_reset_poll]
+help_string = "Remove all user votes on a poll."
+description = "Resets a poll to have no votes on it. You must be the creator of the poll to reset it."
+usage = "<poll menu ID>"
+readme_url = "https://github.com/FragSoc/esports-bot#votes-reset-poll-menu-id"
+
 [logging]
 channel_set = "Logging channel has been set to <#{channel_id!s}>"
 channel_set_already = "Logging channel already set to this channel"

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -102,6 +102,101 @@ help_string = "Unlinks the currently set music channel from being the music chan
 description = "This will just stop the channel from processing song requests, the channel will not be deleted with this command and will just be a regular text channel."
 readme_url = "https://github.com/FragSoc/esports-bot#musicadmin-remove"
 
+[help.pingme]
+help_string = "This is a command group used to create custom roles that have ping cooldown timers."
+readme_url = "https://github.com/FragSoc/esports-bot#pingable-roles"
+
+[help.pingme_settings]
+help_string = "This is a command group used to manage the default settings for pingable roles in this server. These commands require the `administrator` permission in this server."
+readme_url = "https://github.com/FragSoc/esports-bot#pingable-roles"
+
+[help.pingme_settings_get_settings]
+help_string = "Shows the current settings for this server."
+description = "The settings shown are the default settings applied to new roles when they are created. Polls and Roles can have some of their settings overridden with other pingme settings commands."
+readme_url = "https://github.com/FragSoc/esports-bot#pingme-settings-get-settings"
+
+[help.pingme_settings_default_settings]
+help_string = "Resets all settings for this server to the bot-defined defaults."
+readme_url = "https://github.com/FragSoc/esports-bot#pingme-settings-default-settings"
+
+[help.pingme_settings_poll_length]
+help_string = "Sets the default poll length to the given time in seconds."
+description = "This is the default length used in a poll if when no poll length is given when creating a poll."
+usage = "<poll length in seconds>"
+readme_url = "https://github.com/FragSoc/esports-bot#pingme-settings-poll-length-poll-length-in-seconds"
+
+[help.pingme_settings_poll_threshold]
+help_string = "Sets the number of votes required for a poll to pass."
+description = "If a poll passes or equals the value set here, when finished a pingable role will be created with the default settings and all users who voted will be granted the new role."
+usage = "<number of votes required>"
+readme_url = "https://github.com/FragSoc/esports-bot#pingme-settings-poll-threshold-number-of-votes-threshold"
+
+[help.pingme_settings_ping_cooldown]
+help_string = "Sets the default ping cooldown for new pingable roles."
+description = "This cooldown is the time in which the role cannot be mentioned again. This ping cooldown will only apply to new roles created, and will not affect roles previously created with the default ping cooldown."
+usage = "<ping cooldown in seconds>"
+readme_url = "https://github.com/FragSoc/esports-bot#pingme-settings-ping-cooldown-cooldown-in-seconds"
+
+[help.pingme_settings_poll_emoji]
+help_string = "Sets the emoji used in voting polls."
+description = "This sets the emoji that users use to vote on if they want a new pingable role. This will not affect any already running polls."
+usage = "<emoji>"
+readme_url = "https://github.com/FragSoc/esports-bot#pingme-settings-poll-emoji-emoji"
+
+[help.pingme_settings_role_emoji]
+help_string = "Sets the emoji used in the role reaction menu."
+description = "Once a role is created it will also create a role reaction menu so that users who didn't vote but want the role can get the role. This command sets the emoji for the reaction used to get or remove the role from a user. This will not affect any already existing role reaction menus."
+usage = "<emoji>"
+readme_url = "https://github.com/FragSoc/esports-bot#pingme-settings-role-emoji-emoji"
+
+[help.pingme_create_role]
+help_string = "Creates a new poll to create a new role."
+description = "Creates a new poll for users to vote on. If the number of votes surpasses the servers defined vote threshold, a new role is created with the name given in this command. The role will be given to all users who voted and a reaction menu will be created so users who have the role can remove it and users who want the role can receive it."
+usage="<role name> [Optional: poll length in seconds]"
+readme_url = "https://github.com/FragSoc/esports-bot#pingme-create-role-role-name-optional-poll-length-in-seconds"
+
+[help.pingme_delete_role]
+help_string = "Deletes the roles mentioned."
+description = "Completely deletes all roles mentioned, as long as the roles mentioned are pingable roles. This command cannot delete roles that are not pingable roles."
+usage = "<one or many role mentions>"
+readme_url = "https://github.com/FragSoc/esports-bot#pingme-delete-role-one-or-many-role-mentions"
+
+[help.pingme_convert_role]
+help_string = "Converts a mentioned role into a pingable one."
+description = "This creates the reaction menu for the role and makes it a role that has a ping cooldown, which by default is the server default ping cooldown timer."
+usage = "<one or many role mentions>"
+readme_url = "https://github.com/FragSoc/esports-bot#pingme-convert-role-one-or-many-role-mentions"
+
+[help.pingme_convert_pingable]
+help_string = "Converts a mentioned role from a pingable role to a normal one."
+description = "This will make it so that the role is no longer bound by a cooldown as to how many often it can be mentioned. It will also mean that there will no longer be a reaction menu for users to receive a role."
+usage = "<one or many role mentions>"
+readme_url = "https://github.com/FragSoc/esports-bot#pingme-convert-pingable-one-or-many-role-mentions"
+
+[help.pingme_role_cooldown]
+help_string = "Sets the ping cooldown for the given role."
+description = "This will set the number of seconds users must wait before the role can be mentioned again."
+usage = "<role mention | role ID> <cooldown in seconds>"
+readme_url = "https://github.com/FragSoc/esports-bot#pingme-role-cooldown-role-mention--role-id-cooldown-in-seconds"
+
+[help.pingme_role_emoji]
+help_string = "Sets the emoji for the given role."
+description = "If the mentioned role is a pingable role, this will set the emoji used in the role's reaction menu."
+usage = "<role mention | role ID> <emoji>"
+readme_url = "https://github.com/FragSoc/esports-bot#pingme-role-emoji-role-mention--role-id-emoji"
+
+[help.pingme_disable_role]
+help_string = "Disables a pingable role."
+description = "If the role mentioned is a pingable role, this will stop it from being mentioned and will also disable the reaction menu for the role."
+usage = "<one or many role mentions>"
+readme_url = "https://github.com/FragSoc/esports-bot#pingme-disable-role-one-or-many-role-mentions"
+
+[help.pingme_enable_role]
+help_string = "Enables a pingable role."
+description = "If the role mentioned is a pingable role, it will allow the role to be mentioned with it's mention cooldown in place and will enable the reaction menu."
+usage = "<one or many role mentions>"
+readme_url = "https://github.com/FragSoc/esports-bot#pingme-enable-role-one-or-many-role-mentions"
+
 [logging]
 channel_set = "Logging channel has been set to <#{channel_id!s}>"
 channel_set_already = "Logging channel already set to this channel"

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -347,6 +347,51 @@ description = "This will create a reaction menu to confirm your choice. If confi
 usage = "<event name>"
 readme_url = "https://github.com/FragSoc/esports-bot#events-delete-event-event-name"
 
+[help.roles]
+help_string = "This is a command group for controlling the creation of role reaction menus. Use the help command for this command to see the subcommands available."
+readme_url = "https://github.com/FragSoc/esports-bot#role-reaction-menus"
+
+[help.roles_make_menu]
+help_string = "Create a new role menu."
+description = "This will create a new role reaction menu with the given title and description, so long as each are surrounded with double quotes. Each option in the menu is defined with a role and an emoji as its identifier. Each emoji must be unique, but roles do not."
+usage = "<title> <description> [none or many: <role mention> <emoji>]"
+readme_url = "https://github.com/FragSoc/esports-bot#roles-make-menu-title-description-mentioned-role-emoji"
+
+[help.roles_add_option]
+help_string = "Add another option to an existing role menu."
+description = "Adds another option to an existing role menu. The emoji must not already be another option in the role menu, but the role can be any existing role."
+usage = "<role menu ID> [none or many: <role mention> <emoji>]"
+readme_url = "https://github.com/FragSoc/esports-bot#roles-add-option-optional-menu-id-mentioned-role-emoji"
+
+[help.roles_remove_option]
+help_string = "Remove an option from an existing role menu."
+description = "Using the emoji to identify which option you want to remove from the role menu, remove the option from that given menu."
+usage = "<role menu ID> <emoji option to remove>"
+readme_url = "https://github.com/FragSoc/esports-bot#roles-remove-option-emoji-optional-menu-id"
+
+[help.roles_disable_menu]
+help_string = "Disables a role menu."
+description = "This stops users from being able to react to a role reaction menu to receive the roles defined in the menu."
+usage = "<role menu ID>"
+readme_url = "https://github.com/FragSoc/esports-bot#roles-disable-menu-optional-menu-id"
+
+[help.roles_enable_menu]
+help_string = "Enables a role menu."
+description = "Allows users to receive roles from a role reaction menu when they react with the defined emojis in the menu."
+usage = "<role menu ID>"
+readme_url = "https://github.com/FragSoc/esports-bot#roles-enable-menu-optional-menu-id"
+
+[help.roles_delete_menu]
+help_string = "Deletes a role menu."
+description = "Deletes a menu entirely. Does not delete the roles or emojis associated with the menu."
+usage = "<role menu ID>"
+readme_url = "https://github.com/FragSoc/esports-bot#roles-delete-menu-menu-id"
+
+[help.roles_toggle_ids]
+help_string = "Toggle showing IDs at the bottom of role menus."
+description = "This will hide or show the menu ID of all role reaction menus in their footer."
+readme_url = "https://github.com/FragSoc/esports-bot#roles-toggle-ids"
+
 [logging]
 channel_set = "Logging channel has been set to <#{channel_id!s}>"
 channel_set_already = "Logging channel already set to this channel"

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -197,6 +197,40 @@ description = "If the role mentioned is a pingable role, it will allow the role 
 usage = "<one or many role mentions>"
 readme_url = "https://github.com/FragSoc/esports-bot#pingme-enable-role-one-or-many-role-mentions"
 
+[help.setvmparent]
+help_string = "Sets a channel to be a parent channel."
+description = "This will set the voice channel given to act as a parent channel, so when users join they will be moved into their own child-channel. There can be more than 1 parent voice channel."
+usage = "<voice channel ID>"
+readme_url = "https://github.com/FragSoc/esports-bot#setvmparent-channel_id"
+
+[help.getvmparents]
+help_string = "Get a list of all Voicemaster parent channels."
+readme_url = "https://github.com/FragSoc/esports-bot#getvmparents"
+
+[help.removevmparent]
+help_string = "Stops the given voice channel from acting as a Voicemaster parent."
+usage = "<voice channel ID>"
+readme_url = "https://github.com/FragSoc/esports-bot#removevmparent-channel_id"
+
+[help.removeallparents]
+help_string = "Stops all voice channels from acting as Voicemaster parents."
+readme_url = "https://github.com/FragSoc/esports-bot#removeallparents"
+
+[help.removeallchildren]
+help_string = "Deletes all Voicemaster child voice channels."
+readme_url = "https://github.com/FragSoc/esports-bot#removeallchildren"
+
+[help.lockvm]
+help_string = "Locks your current Voicemaster voice channel."
+description = "If you are in a Voicemaster child channel and if you own the channel, it will lock the number of users allowed in the channel to the current number of users in the channel."
+readme_url = "https://github.com/FragSoc/esports-bot#lockvm"
+
+[help.unlockvm]
+help_string = "Unlocks your current Voicemaster voice channel."
+description = "If you are in a Voicemaster child channel and if you own the channel, it will remove the user-count limit."
+readme_url = "https://github.com/FragSoc/esports-bot#unlockvm"
+
+
 [logging]
 channel_set = "Logging channel has been set to <#{channel_id!s}>"
 channel_set_already = "Logging channel already set to this channel"

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -440,7 +440,7 @@ readme_url = "https://github.com/FragSoc/esports-bot#twitch-integration"
 help_string = "Create a new Discord Webhook for Twitch notifications."
 description = "Creates a Webhook with the given name that can be used to post live notifications of specific Twitch channels to the specific Discord text channel the Webhook is bound to."
 usage = "<channel mention> <hook name>"
-readme_url = "https://github.com/FragSoc/esports-bot#twitch-createhook-optional-channel_mention-optional-hook-name"
+readme_url = "https://github.com/FragSoc/esports-bot#twitch-createhook-channel_mention-hook-name"
 
 [help.twitch_deletehook]
 help_string = "Delete an existing Discord Webhook for Twitch notifications."
@@ -452,19 +452,19 @@ readme_url = "https://github.com/FragSoc/esports-bot#twitch-deletehook-hook-name
 help_string = "Adds a Twitch channel to be tracked."
 description = "This will track the given Twitch channel and post its updates to the given discord Webhook. A channel can be bound to many Discord Webhooks. If a custom message is given, it will be used in the live notification and must be surrounded by double quotes."
 usage = "<channel name | channel url> <hook name> [optional: custom message]"
-readme_url = "https://github.com/FragSoc/esports-bot#twitch-add-twitch-handle--twitch-url-optional-custom-message"
+readme_url = "https://github.com/FragSoc/esports-bot#twitch-add-channel-name--channel-url--hook name-optional-custom-message"
 
 [help.twitch_remove]
 help_string = "Stops tracking a Twitch channel."
 description = "This will stop posting updates for the given Twitch channel in the given Webhook's text channel. If the Twitch channel is tracked in other channels, the notifications will still be posted there."
 usage = "<channel name | channel url> <hook name>"
-readme_url = "https://github.com/FragSoc/esports-bot#twitch-remove-twitch-handle"
+readme_url = "https://github.com/FragSoc/esports-bot#twitch-remove-twitch-handle-hook-name"
 
 [help.twitch_list]
 help_string = "Shows a list of the current Discord Webhooks and their tracked channels."
 description = "To only see one Webhooks channels, specify the Webhook name in the command."
 usage = "[optional: hook name]"
-readme_url = "https://github.com/FragSoc/esports-bot#twitch-list"
+readme_url = "https://github.com/FragSoc/esports-bot#twitch-list-optional-hook-name"
 
 [help.twitch_webhooks]
 help_string = "Get a list of the current Discord Webhooks for Twitch."

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -261,6 +261,20 @@ description = "Unloads and then reloads the given cog. Refer to the 'load cog' c
 usage = "<cog name>"
 readme_url = "https://github.com/FragSoc/esports-bot#reload-cog-cog-name"
 
+[help.setlogchannel]
+help_string = "Sets the given channel to the logging channel."
+usage = "<channel mention | channel ID>"
+readme_url = "https://github.com/FragSoc/esports-bot#setlogchannel-channel_mention--channel_id"
+
+[help.getlogchannel]
+help_string = "Get the current logging channel."
+readme_url = "https://github.com/FragSoc/esports-bot#getlogchannel"
+
+[help.removelogchannel]
+help_string = "Stops the current logging channel from being active."
+description = "The current logging channel will become a regular channel and logging events will no longer be posted to the channel."
+readme_url = "https://github.com/FragSoc/esports-bot#removelogchannel"
+
 [logging]
 channel_set = "Logging channel has been set to <#{channel_id!s}>"
 channel_set_already = "Logging channel already set to this channel"

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -74,6 +74,10 @@ description = "This will move a song at the first position to the second positio
 usage = "<from position> <to position>"
 readme_url = "https://github.com/FragSoc/esports-bot#music-move-from-position-to-position"
 
+[help.musicadmin]
+help_string = "This is a command group for managing the music channel, all of these commands require the `administrator` permission in this server. Just executing this command will not do anything, use the help command for this command to see the list of all admin commands."
+readme_url = "https://github.com/FragSoc/esports-bot#music-bot"
+
 [help.musicadmin_fix]
 help_string = "Performs a hard reset on the music channels and the current state of the music bot in this server."
 description = "This should only be needed if there is an issue where the bot thinks it is still in a channel and then won't join a new one. Before using this command you should try the `join` or `kick` commands with `-f` or `force` first."

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -230,6 +230,36 @@ help_string = "Unlocks your current Voicemaster voice channel."
 description = "If you are in a Voicemaster child channel and if you own the channel, it will remove the user-count limit."
 readme_url = "https://github.com/FragSoc/esports-bot#unlockvm"
 
+[help.clear]
+help_string = "Deletes the given number of messages. Defaults to 5 messages."
+usage = "<number of messages>"
+readme_url = "https://github.com/FragSoc/esports-bot#clear"
+
+[help.version]
+help_string = "Get the current bot version."
+readme_url = "https://github.com/FragSoc/esports-bot#version"
+
+[help.members]
+help_string = "Get the number of members in the server."
+readme_url = "https://github.com/FragSoc/esports-bot#members"
+
+[help.remove_cog]
+help_string = "Unloads the given cog."
+description = "This removes a cog from being loaded and removes all its commands. This can only be run by a member that is defined in the dev_ids section of the bots environment. If a cog makes use of the `on_ready` function, it will not work properly if loaded through the command, and will require a full restart to re-enable."
+usage = "<cog name>"
+readme_url = "https://github.com/FragSoc/esports-bot#remove-cog-cog-name"
+
+[help.add_cog]
+help_string = "Loads the given cog."
+description = "Enables a Cog and adds its commands. This can only be run by a member that is defined in the dev_ids section of the bots environment. If the given cog uses the `on_ready` function, it will not work as expected and will require a full restart to properly enable."
+usage ="<cog name>"
+readme_url = "https://github.com/FragSoc/esports-bot#add-cog-cog-name"
+
+[help.reload_cog]
+help_string = "Reloads the given cog."
+description = "Unloads and then reloads the given cog. Refer to the 'load cog' command to see potential side-effects. This can only be run by a member that is defined in the dev_ids section of the bots environment."
+usage = "<cog name>"
+readme_url = "https://github.com/FragSoc/esports-bot#reload-cog-cog-name"
 
 [logging]
 channel_set = "Logging channel has been set to <#{channel_id!s}>"

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -305,6 +305,20 @@ readme_url = "https://github.com/FragSoc/esports-bot#twitter-remove-twitter-hand
 help_string = "Lists all the Twitter accounts currently tracked."
 readme_url = "https://github.com/FragSoc/esports-bot#twitter-list"
 
+[help.setdefaultroles]
+help_string = "Sets the list of roles to be given to users when they join the server."
+usage = "<one or many role mentions>"
+readme_url = "https://github.com/FragSoc/esports-bot#setdefaultroles-role_mention--role_id"
+
+[help.getdefaultroles]
+help_string = "Get the list of current default roles."
+readme_url = "https://github.com/FragSoc/esports-bot#getdefaultroles"
+
+[help.removedefaultroles]
+help_string = "Removes all default roles."
+description = "This will stop applying the current list of default roles to new members. Does not affect existing members."
+readme_url = "https://github.com/FragSoc/esports-bot#removedefaultroles"
+
 [logging]
 channel_set = "Logging channel has been set to <#{channel_id!s}>"
 channel_set_already = "Logging channel already set to this channel"

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -319,6 +319,34 @@ help_string = "Removes all default roles."
 description = "This will stop applying the current list of default roles to new members. Does not affect existing members."
 readme_url = "https://github.com/FragSoc/esports-bot#removedefaultroles"
 
+[help.events]
+help_string = "This is a command group for controlling the creation and management of events and their text and voice channels. Use the help command for this command to see the subcommands available."
+readme_url = "https://github.com/FragSoc/esports-bot#event-category-management"
+
+[help.events_create_event]
+help_string = "Creates a new event with a given name."
+description = "This command will create the Discord category, the sign-in channel, a general text channel and a voice channel with the event's name as well as an event role. The sign-in menu will be a role react menu to receive the event role and until the event is open, all channels in the category will be set to private and only viewable by administrators. Once open, the sign-in channel will be visible to members with the given shared role. If no shared role is supplied, the shared role used will be one of the DefaultRoles."
+usage = "<event name> [optional: shared role]"
+readme_url = "https://github.com/FragSoc/esports-bot#events-create-event-event-name-role-mention--role-id"
+
+[help.events_open_event]
+help_string = "Reveal the sign-in menu to non-administrators."
+description = "Allows members with the shared role to see the sign-in channel, and then also react to the sign-in menu to receive the event role."
+usage = "<event name>"
+readme_url = "https://github.com/FragSoc/esports-bot#events-open-event-event-name"
+
+[help.events_close_event]
+help_string = "Stop members from seeing all event channels."
+description = "Stops all channels in the event category from being viewed by non-administrators. This does not remove the event role from users."
+usage = "<event name>"
+readme_url = "https://github.com/FragSoc/esports-bot#events-close-event-event-name"
+
+[help.events_delete_event]
+help_string = "Delete all event channels and the event role."
+description = "This will create a reaction menu to confirm your choice. If confirmed, all channels and the event role will be deleted."
+usage = "<event name>"
+readme_url = "https://github.com/FragSoc/esports-bot#events-delete-event-event-name"
+
 [logging]
 channel_set = "Logging channel has been set to <#{channel_id!s}>"
 channel_set_already = "Logging channel already set to this channel"

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -2,6 +2,99 @@ command_error_generic = "There was an internal error while performing your comma
 command_error_required_arguments = "Arguments are required for this command! See `{command_prefix}help {command_used}` for more information."
 guild_leave = "Left the guild: {guild_name}"
 
+[help]
+command_footer = "• Parameters with `<>` around them are required parameters.\n• Parameters with `[]` are optional parameters.\n• The brackets are not required when executing the command."
+embed_footer = "For more help go to https://github.com/FragSoc/esports-bot"
+command_help = "• Help Command: {help_string}"
+command_alias = "• Aliases: {aliases}"
+empty_category = "No Category"
+embed_title = "Showing help for Showing help for — {prefix}{name}"
+usage_string = "{prefix}{fqn}"
+
+[help.music]
+help_string = "This is a command group for controlling music playback. All subcommands of this one can only be run in the music channel. Just executing this command will not do anything, use `{prefix}help music` to find a list of all the music commands."
+readme_url = "https://github.com/FragSoc/esports-bot#music-bot"
+
+[help.music_queue]
+help_string = "Gets the current list of songs in the queue."
+description = "Unlike the active queue in the music channel, this command will show the entire queue. This command does not take any parameters."
+readme_url = "https://github.com/FragSoc/esports-bot#music-queue"
+
+[help.music_join]
+help_string = "Make the bot join the channel."
+description = "This command makes the bot join a channel. If the bot is already in another channel it won't join. If an admin executes this command, they can force it to join by using `-f` or `force` at the end of the command."
+usage = "[optional: -f | force]"
+readme_url = "https://github.com/FragSoc/esports-bot#music-join-optional--f--force"
+
+[help.music_kick]
+help_string = "Kicks the bot from the voice channel."
+description = "This command makes the bot leave the current voice channel. If you are not in the channel with the bot, it won't leave. If an admin executes this command, they can force it to leave any channel by using `-f` or `force` at the end of the command."
+usage = "[optional: -f | force]"
+readme_url = "https://github.com/FragSoc/esports-bot#music-kick-optional--f--force"
+
+[help.music_skip]
+help_string = "Skips the currently playing song."
+description = "This command can skip 1 or many songs. If you give the command a number, it will skip to that song number in the queue. For example, if you give it the number `4`, it will start playing song number `4` in the queue, and remove all songs before that song. If you are not in the voice channel with the bot, this command will have no effect."
+usage = "[optional: skip to song number]"
+readme_url = "https://github.com/FragSoc/esports-bot#music-skip-optional-skip-to-position"
+
+[help.music_volume]
+help_string = "Sets the volume of the bot."
+description = "This sets the volume for all users in the channel, and gets reset if the bot leaves. Note that this will not change the bots independent volume slider that exists for all users. If you are not in the voice channel with the bot, this command will have no effect."
+usage = "<volume level %>"
+readme_url = "https://github.com/FragSoc/esports-bot#music-volume-volume-level"
+
+[help.music_clear]
+help_string = "Clears the entire queue."
+description = "This will clear the entire queue, but will not remove the currently playing song. If you are not in the voice channel with the bot, this command will have no effect."
+readme_url = "https://github.com/FragSoc/esports-bot#music-clear"
+
+[help.music_resume]
+help_string = "Resumes playback of the current song or starts playback of the given song."
+description = "If there is a song that is currently playing, it will continue playing. If there are no songs currently paused or in queue and a song is given to the command, it will start playing the given song. If there are songs in the queue, or there is a paused song, the song will be added to the queue. If you are not in the voice channel with the bot, this command will have no effect."
+usage = "[optional: song request]"
+readme_url = "https://github.com/FragSoc/esports-bot#music-play-optional-song-request"
+
+[help.music_pause]
+help_string = "Pauses the current song."
+readme_url = "https://github.com/FragSoc/esports-bot#music-pause"
+
+[help.music_remove]
+help_string = "Removes a song from the queue at a specific position."
+description = "If there is a song at the position given, it will remove that song from the queue. If no song position is given, it will remove the first song in the queue. If you are not in the voice channel with the bot, this command will have no effect."
+usage = "[optional: song number]"
+readme_url = "https://github.com/FragSoc/esports-bot#music-remove-song-position"
+
+[help.music_move]
+help_string = "Moves a song from one position in the queue to another."
+description = "This will move a song at the first position to the second position. It will not swap the song at the second position to the first position."
+usage = "<from position> <to position>"
+readme_url = "https://github.com/FragSoc/esports-bot#music-move-from-position-to-position"
+
+[help.musicadmin_fix]
+help_string = "Performs a hard reset on the music channels and the current state of the music bot in this server."
+description = "This should only be needed if there is an issue where the bot thinks it is still in a channel and then won't join a new one. Before using this command you should try the `join` or `kick` commands with `-f` or `force` first."
+readme_url = "https://github.com/FragSoc/esports-bot#musicadmin-fix"
+
+[help.musicadmin_set]
+help_string = "Sets the music channel for this server."
+description = "By default this command will just send the song queue and current song preview messages. You can also use the `-c` optional arg to clear the channel first."
+usage = "<channel mention> [optional: [args]"
+readme_url = "https://github.com/FragSoc/esports-bot#musicadmin-set-channel-mention-optional-args"
+
+[help.musicadmin_get]
+help_string = "Gets the channel that is currently set as the music channel in this server."
+readme_url = "https://github.com/FragSoc/esports-bot#musicadmin-get"
+
+[help.musicadmin_reset]
+help_string = "Clears the music channel and performs the setup again."
+readme_url = "https://github.com/FragSoc/esports-bot#musicadmin-reset"
+
+[help.musicadmin_remove]
+help_string = "Unlinks the currently set music channel from being the music channel."
+description = "This will just stop the channel from processing song requests, the channel will not be deleted with this command and will just be a regular text channel."
+readme_url = "https://github.com/FragSoc/esports-bot#musicadmin-remove"
+
 [logging]
 channel_set = "Logging channel has been set to <#{channel_id!s}>"
 channel_set_already = "Logging channel already set to this channel"


### PR DESCRIPTION
By removing the folding of the sections, the URLs in the help commands will take users directly to the section pertaining to the command they are looking at.

Currently, unless the section is expanded, the URLs go to the top of the README, making them redundant.