### PR TITLE
Fixed missing field in DB Row creation for pingable settings

### DIFF
--- a/src/esportsbot/cogs/PingableRolesCog.py
+++ b/src/esportsbot/cogs/PingableRolesCog.py
@@ -112,6 +112,7 @@ class PingableRolesCog(commands.Cog):
                 guild_id=guild.id,
                 default_poll_length=int(os.getenv("DEFAULT_POLL_LENGTH")),
                 default_poll_threshold=int(os.getenv("DEFAULT_POLL_THRESHOLD")),
+                default_cooldown_length=int(os.getenv("DEFAULT_COOLDOWN_LENGTH")),
                 default_poll_emoji=PINGABLE_POLL_EMOJI.to_dict(),
                 default_role_emoji=PINGABLE_ROLE_EMOJI.to_dict()
             )


### PR DESCRIPTION
Fixed issue that joining a new guild would cause an error due to a null value as the `default_role_cooldown` value was missing from the row creation.