### PR TITLE
Command to easily set Game Rep permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ The list below describes the different "Cogs" of the bot, their associated comma
 * Reloads the given cog.
 * *This command requires your user ID to be defined in the env file under `DEV_IDS`*
 
+#### !set-rep \<user mention> \<channel or category IDs>
+* Sets the permissions for a user in the channels/categories given.
+* *Requires `administrator` permission in Discord*
+
 </details>
 
 <details>

--- a/src/esportsbot/cogs/AdminCog.py
+++ b/src/esportsbot/cogs/AdminCog.py
@@ -119,6 +119,9 @@ class AdminCog(commands.Cog):
         :param context: The context of the command.
         :param user: The user to give the permissions to.
         """
+
+        channel_names = []
+
         for category in args:
             try:
                 category_id = int(category)
@@ -128,39 +131,47 @@ class AdminCog(commands.Cog):
                 # First remove any existing reps/overwrites.
                 await self.remove_user_permissions(discord_category)
                 # Then add the new user's permissions.
-                await self.set_rep_permissions(user, discord_category)
+                if await self.set_rep_permissions(user, discord_category):
+                    channel_names.append(discord_category.name)
             except ValueError:
                 continue
+
+        response_string = str(channel_names).replace("[", "").replace("]", "").strip()
+        await context.send(f"Successfully set the permissions for `{user.display_name}#{user.discriminator}` "
+                           f"in the following channels/categories: `{response_string}`")
 
     async def remove_user_permissions(self, guild_channel):
         """
         Removes permission overrides that are for specific users for a given GuildChannel.
         :param guild_channel: The channel to remove any user-based permission overrides.
+        :return True if any user-based permissions were removed, False if this process failed.
         """
-        current_overwrites = guild_channel.overwrites
-        for permission_group in guild_channel.overwrites:
-            # We can't remove the default owner permissions as this throws a Forbidden error.
-            if isinstance(permission_group, Member) and permission_group != guild_channel.guild.owner:
-                current_overwrites.pop(permission_group)
+        if not await self.check_editable(guild_channel):
+            return False
 
-        # Reduce API spam by only updating when the permissions have changed.
-        if current_overwrites != guild_channel.overwrites:
-            await guild_channel.edit(overwrites=current_overwrites)
+        for permission_group in guild_channel.overwrites:
+            if isinstance(permission_group, Member):
+                await guild_channel.set_permissions(target=permission_group, overwrite=None)
 
         # If the channel provided is category, go through the channels inside the category and remove the permissions.
         if not isinstance(guild_channel, CategoryChannel):
-            return
+            return True
 
         for channel in guild_channel.channels:
             await self.remove_user_permissions(channel)
 
-    @staticmethod
-    async def set_rep_permissions(user, guild_channel):
+        return True
+
+    async def set_rep_permissions(self, user, guild_channel):
         """
         Sets the permissions of a user to those that a rep would need in the given category/channel.
         :param user: The user to give the permissions to.
         :param guild_channel: The GuildChannel to set the permissions of.
+        :return True if the permissions were set for the given user, False otherwise.
         """
+        if not await self.check_editable(guild_channel):
+            return False
+
         overwrite = PermissionOverwrite(
             view_channel=True,
             manage_channels=True,
@@ -177,11 +188,29 @@ class AdminCog(commands.Cog):
 
         # If the channel provided is a category, ensure that the rep can type in any announcement channels.
         if not isinstance(guild_channel, CategoryChannel):
-            return
+            return True
 
         for channel in guild_channel.channels:
             if isinstance(channel, TextChannel) and channel.is_news():
                 await channel.set_permissions(target=user, send_messages=True)
+
+        return True
+
+    @staticmethod
+    async def check_editable(guild_channel):
+        """
+        Checks if the bot has permission to edit the permissions of a channel.
+        :param guild_channel: The channel to check the permissions of.
+        :return: True if the bot is able to edit the permissions of the channel, else False.
+        """
+        bot_perms = guild_channel.permissions_for(guild_channel.guild.me)
+        bot_overwrites = guild_channel.overwrites_for(guild_channel.guild.me)
+        if not bot_perms.manage_permissions:
+            return False
+        # Explicitly check for False, as None means no overwrite.
+        if bot_overwrites.manage_permissions is False:
+            return False
+        return True
 
 
 def setup(bot):

--- a/src/esportsbot/cogs/AdminCog.py
+++ b/src/esportsbot/cogs/AdminCog.py
@@ -113,21 +113,16 @@ class AdminCog(commands.Cog):
 
     @commands.has_permissions(administrator=True)
     @commands.command(name="set-rep")
-    async def set_rep_perms(self, context: commands.Context, user):
+    async def set_rep_perms(self, context: commands.Context, user, *args):
         """
         Sets the permissions for a game rep given a list of category or channel ids.
         :param context: The context of the command.
         :param user: The user to give the permissions to.
         """
-        message = context.message.content
-        user_str = str(user)
-        category_list = message[message.index(user_str) + len(user_str):].strip()  # This gets just the channel ids.
-        category_ids = category_list.split(" ")  # Put them into a list.
-
-        for category in category_ids:
+        for category in args:
             try:
                 category_id = int(category)
-                discord_category = context.guild.get_Channel(category_id)
+                discord_category = context.guild.get_channel(category_id)
                 if not discord_category:
                     discord_category = await self.bot.fetch_channel(category_id)
                 # First remove any existing reps/overwrites.

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -261,6 +261,12 @@ description = "Unloads and then reloads the given cog. Refer to the 'load cog' c
 usage = "<cog name>"
 readme_url = "https://github.com/FragSoc/esports-bot#reload-cog-cog-name"
 
+[help.set_rep]
+help_string = "Sets the permissions for a game rep."
+description = "By mentioning a user, and then giving a set of category or channel IDs separated by a space, this command will give the required permissions for a Game Rep for the given channels."
+usage = "<user mention> <channel or category ids>"
+readme_url = "https://github.com/FragSoc/esports-bot#set-rep-user-mention-channel-or-category-ids"
+
 [help.setlogchannel]
 help_string = "Sets the given channel to the logging channel."
 usage = "<channel mention | channel ID>"


### PR DESCRIPTION
From the experience of setting the permissions of each Game Rep for each game in each category they need access to, this process needed to be automated somehow.

I've added command that takes a user and a list of channel/category IDs, and then sets the permissions needed for a Game Rep to control their section and remove any previous user's permission overwrites so that this can be used when new Game Reps come in.

Also I know that I don't actually need a review to merge this, but just thought that it would be good practice.