### PR TITLE
Fixed an issue caused by the FragSoc website moving

### DIFF
--- a/src/esportsbot/cogs/MusicCog.py
+++ b/src/esportsbot/cogs/MusicCog.py
@@ -63,7 +63,7 @@ class MessageTypeEnum(IntEnum):
 EMPTY_QUEUE_MESSAGE = "Join a Voice Channel and search a song by name or paste a YouTube url.\n" \
                       "**__Current Queue:__**\n"
 
-ESPORTS_LOGO_URL = "http://fragsoc.co.uk/wpsite/wp-content/uploads/2020/08/logo1-450x450.png"
+ESPORTS_LOGO_URL = "https://static.wixstatic.com/media/d8a4c5_b42c82e4532c4f8e9f9b2f2d9bb5a53e~mv2.png/v1/fill/w_287,h_287,al_c,q_85,usm_0.66_1.00_0.01/esportslogo.webp"
 
 EMPTY_PREVIEW_MESSAGE = Embed(
     title="No song currently playing",


### PR DESCRIPTION
The url of the viking logo no longer existed as the FragSoc.co.uk site is no longer a valid site, and hence the image used no longer existed. Updated the url to point to the new website.