### PR TITLE
No longer pings user when getdefaultroles is used

### DIFF
--- a/src/esportsbot/cogs/DefaultRoleCog.py
+++ b/src/esportsbot/cogs/DefaultRoleCog.py
@@ -1,4 +1,5 @@
 from discord.ext import commands, tasks
+from discord import Embed
 from esportsbot.db_gateway import DBGatewayActions
 from esportsbot.models import GuildInfo, DefaultRoles
 from esportsbot.base_functions import role_id_from_mention
@@ -144,7 +145,7 @@ class DefaultRoleCog(commands.Cog):
             apply_roles = [ctx.author.guild.get_role(role.role_id) for role in guild_default_roles]
             # Return all the default roles to the user
             await ctx.channel.send(
-                self.STRINGS['default_role_get'].format(role_ids=(' '.join(f'<@&{x.id}>' for x in apply_roles)))
+                embed=Embed(title=self.STRINGS['default_role_get'], description="— "+('\n— '.join(f'<@&{x.id}>' for x in apply_roles)))
             )
         else:
             await ctx.channel.send(self.STRINGS['default_role_missing'])

--- a/src/esportsbot/cogs/DefaultRoleCog.py
+++ b/src/esportsbot/cogs/DefaultRoleCog.py
@@ -55,9 +55,6 @@ class DefaultRoleCog(commands.Cog):
             self.pending_members.remove(member)
 
     async def apply_roles(self, member):
-        guild = DBGatewayActions().get(GuildInfo, guild_id=member.guild.id)
-        if not guild:
-            return
         # Get all the default role for the server from database
         guild_default_roles = DBGatewayActions().list(DefaultRoles, guild_id=member.guild.id)
         # Check to see if any roles exist

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -529,7 +529,7 @@ default_roles_set_empty = "No roles were passed, please review your usage"
 default_roles_set_error = "Error occurred during this operation, please check that you have formatted these inputs correctly"
 default_roles_set_log = "{author_mention} has set the default role(s) to: {roles}"
 
-default_role_get = "Default role(s) are set to {role_ids}"
+default_role_get = "Default role(s) are set to:"
 
 default_role_removed = "Default role(s) are removed"
 default_role_removed_log = "{author_mention} has removed the default role"


### PR DESCRIPTION
The `getdefaultroles` command now uses and embed to avoid pinging users 