### PR TITLE
Put the command prefix in the activity message

### DIFF
--- a/src/esportsbot/bot.py
+++ b/src/esportsbot/bot.py
@@ -21,7 +21,7 @@ async def on_ready():
     await client.change_presence(
         status=discord.Status.dnd,
         activity=discord.Activity(type=discord.ActivityType.listening,
-                                  name="your commands")
+                                  name=f"commands using {os.getenv('COMMAND_PREFIX')}")
     )
 
 


### PR DESCRIPTION
Allows users to see which prefix to use for commands by looking at the activity status of the bot